### PR TITLE
Include only what each test needs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.15)
 
 add_executable(${PROJECT_NAME}
+	pairwise_ranking.cpp
 	constants.h
 	functions.cpp
 	functions.h
 	helpers.cpp
 	helpers.h
-	pairwise_ranking.cpp
 	print.cpp
 	print.h
 	voting_round.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,50 +2,180 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_testing()
 
-list(APPEND test_helper_files
+set(test_name test_calculate_scores)
+add_executable(${test_name}
+	${test_name}.cpp
 	testing.cpp
-	testing.h
-	${PROJECT_SOURCE_DIR}/src/functions.cpp
-	${PROJECT_SOURCE_DIR}/src/functions.h
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/helpers.h
 	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/print.h
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.h
-)
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
 
-list(APPEND tests
-	test_load_and_save_file
-	
-	# Tests for generation and convertion of voting round
-	test_generate_new_voting_round
-	test_parse_voting_round
-	test_generate_voting_round_file_data
-	test_verify_voting_round
-	
-	# Tests for modification of votes
-	test_shuffle_voting_order
-	test_prune_votes
-	
-	# Tests for calculation and presentation of score
-	test_calculate_scores
-	test_combine_scores
-	test_create_score_table
-	test_generate_score_file_data
-	test_parse_scores
-	
-	test_current_voting_line
-	test_get_active_menu_string
+set(test_name test_combine_scores)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
 
-	test_undo
-	test_vote
+set(test_name test_create_score_table)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
 
-	test_item_order_randomized
-)
+set(test_name test_current_voting_line)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
 
-foreach(test_name ${tests})
-	add_executable(${test_name} ${test_name}.cpp ${test_helper_files})
-	target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-	add_test(NAME ${test_name} COMMAND ${test_name})
-endforeach()
+set(test_name test_generate_new_voting_round)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_generate_score_file_data)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_generate_voting_round_file_data)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_get_active_menu_string)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_item_order_randomized)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_load_and_save_file)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_parse_scores)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_parse_voting_round)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_prune_votes)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_shuffle_voting_order)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_undo)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_verify_voting_round)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})
+
+set(test_name test_vote)
+add_executable(${test_name}
+	${test_name}.cpp
+	testing.cpp
+	${PROJECT_SOURCE_DIR}/src/functions.cpp
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
+target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+add_test(NAME ${test_name} COMMAND ${test_name})

--- a/src/test/test_calculate_scores.cpp
+++ b/src/test/test_calculate_scores.cpp
@@ -1,12 +1,14 @@
-#include "functions.h"
-#include "helpers.h"
+//#include "functions.h"
+//#include "helpers.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {
 auto findScoreForItem(Scores const& scores, std::string const& item) -> Score {
 	return *std::find_if(scores.begin(), scores.end(), [&item](Score const& score) {
-		return score.item == item; });
+		return score.item == item;
+	});
 }
 auto currentOptionItems(VotingRound const& voting_round) -> std::pair<std::string, std::string> {
 	auto const index_pair = voting_round.index_pairs[voting_round.votes.size()];
@@ -18,7 +20,7 @@ void zeroVotes() {
 }
 void oneVoteForA() {
 	std::optional<VotingRound> voting_round{ VotingRound::create({"item1", "item2"}, false) };
-	vote(voting_round, Option::A);
+	voting_round.value().vote(Option::A);
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
 	ASSERT_EQ(findScoreForItem(scores, "item1"), Score{ "item1", 1, 0 });
@@ -26,7 +28,7 @@ void oneVoteForA() {
 }
 void oneVoteForB() {
 	std::optional<VotingRound> voting_round{ VotingRound::create({"item1", "item2"}, false) };
-	vote(voting_round, Option::B);
+	voting_round.value().vote(Option::B);
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
 	ASSERT_EQ(findScoreForItem(scores, "item1"), Score{ "item1", 0, 1 });
@@ -35,7 +37,7 @@ void oneVoteForB() {
 void allVotesForA() {
 	std::optional<VotingRound> voting_round{ VotingRound::create({"item1", "item2", "item3", "item4"}, false) };
 	for (auto i = 0; i < voting_round.value().numberOfScheduledVotes(); ++i) {
-		vote(voting_round, Option::A);
+		voting_round.value().vote(Option::A);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -49,7 +51,7 @@ void allVotesForA() {
 void allVotesForB() {
 	std::optional<VotingRound> voting_round{ VotingRound::create({"item1", "item2", "item3", "item4"}, false) };
 	for (auto i = 0; i < voting_round.value().numberOfScheduledVotes(); ++i) {
-		vote(voting_round, Option::B);
+		voting_round.value().vote(Option::B);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -66,14 +68,14 @@ void votingForItem2AndOptionAIfNotPresent() {
 		auto const current_items = currentOptionItems(voting_round.value());
 
 		if (current_items.first == "item2") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
 		if (current_items.second == "item2") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
-		vote(voting_round, Option::A);
+		voting_round.value().vote(Option::A);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -91,14 +93,14 @@ void votingForItem3AndOptionAIfNotPresent() {
 		auto const current_items = currentOptionItems(voting_round.value());
 
 		if (current_items.first == "item3") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
 		if (current_items.second == "item3") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
-		vote(voting_round, Option::A);
+		voting_round.value().vote(Option::A);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -116,14 +118,14 @@ void votingForItem2AndOptionBIfNotPresent() {
 		auto const current_items = currentOptionItems(voting_round.value());
 
 		if (current_items.first == "item2") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
 		if (current_items.second == "item2") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
-		vote(voting_round, Option::B);
+		voting_round.value().vote(Option::B);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -141,14 +143,14 @@ void votingForItem3AndOptionBIfNotPresent() {
 		auto const current_items = currentOptionItems(voting_round.value());
 
 		if (current_items.first == "item3") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
 		if (current_items.second == "item3") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
-		vote(voting_round, Option::B);
+		voting_round.value().vote(Option::B);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -166,14 +168,14 @@ void votingForItem2AndAgainstItem3AndOptionAIfNeither() {
 		auto const current_items = currentOptionItems(voting_round.value());
 		
 		if (current_items.first == "item2" || current_items.second == "item3") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
 		if (current_items.second == "item2" || current_items.first == "item3") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
-		vote(voting_round, Option::A);
+		voting_round.value().vote(Option::A);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -191,14 +193,14 @@ void votingForItem2AndAgainstItem3AndOptionBIfNeither() {
 		auto const current_items = currentOptionItems(voting_round.value());
 
 		if (current_items.first == "item2" || current_items.second == "item3") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
 		if (current_items.second == "item2" || current_items.first == "item3") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
-		vote(voting_round, Option::B);
+		voting_round.value().vote(Option::B);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -216,14 +218,14 @@ void votingForItem3AndAgainstItem2AndOptionAIfNeither() {
 		auto const current_items = currentOptionItems(voting_round.value());
 
 		if (current_items.first == "item2" || current_items.second == "item3") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
 		if (current_items.second == "item2" || current_items.first == "item3") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
-		vote(voting_round, Option::A);
+		voting_round.value().vote(Option::A);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -241,14 +243,14 @@ void votingForItem3AndAgainstItem2AndOptionBIfNeither() {
 		auto const current_items = currentOptionItems(voting_round.value());
 
 		if (current_items.first == "item2" || current_items.second == "item3") {
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			continue;
 		}
 		if (current_items.second == "item2" || current_items.first == "item3") {
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			continue;
 		}
-		vote(voting_round, Option::B);
+		voting_round.value().vote(Option::B);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -263,7 +265,7 @@ void votingForItem3AndAgainstItem2AndOptionBIfNeither() {
 void votingForOptionAButNotFullRound() {
 	std::optional<VotingRound> voting_round{ VotingRound::create({"item1", "item2", "item3", "item4"}, false) };
 	for (auto i = 0; i < 4; ++i) {
-		vote(voting_round, Option::A);
+		voting_round.value().vote(Option::A);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());
@@ -280,7 +282,7 @@ void votingForOptionAButNotFullRound() {
 void votingForOptionBButNotFullRound() {
 	std::optional<VotingRound> voting_round{ VotingRound::create({"item1", "item2", "item3", "item4"}, false) };
 	for (auto i = 0; i < 4; ++i) {
-		vote(voting_round, Option::B);
+		voting_round.value().vote(Option::B);
 	}
 	auto const scores = voting_round.value().calculateScores();
 	ASSERT_EQ(scores.size(), voting_round.value().items.size());

--- a/src/test/test_combine_scores.cpp
+++ b/src/test/test_combine_scores.cpp
@@ -3,6 +3,7 @@
 
 namespace
 {
+
 void combiningNoScoreSet() {
 	ASSERT_EQ(combineScores({}).size(), 0ui64);
 }
@@ -45,7 +46,7 @@ void combiningTwoScoreSetsWithDifferentItems() {
 	ASSERT_EQ(combined_scores[1], score2);
 }
 
-}
+} // namespace
 
 int main() {
 	combiningNoScoreSet();

--- a/src/test/test_current_voting_line.cpp
+++ b/src/test/test_current_voting_line.cpp
@@ -1,5 +1,5 @@
-#include "functions.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {
@@ -46,15 +46,15 @@ void itemLengthIsEqualToHeaderLength() {
 }
 void votingIsCompleted() {
 	auto voting_round = VotingRound::create({ "item1", "item2" }, false);
-	vote(voting_round, Option::A);
+	voting_round.value().vote(Option::A);
 	ASSERT_FALSE(voting_round.value().currentVotingLine().has_value());
 }
 void incompleteVotingIncreasesCounterAndChangesItem() {
 	auto voting_round = VotingRound::create({ "item1", "item2", "item3" }, false);
-	vote(voting_round, Option::A);
+	voting_round.value().vote(Option::A);
 	ASSERT_EQ(voting_round.value().currentVotingLine().value(),
 		std::string{ "(2/3) H: help. A: \'item1\'. B: \'item3\'. Your choice: " });
-	vote(voting_round, Option::A);
+	voting_round.value().vote(Option::A);
 	ASSERT_EQ(voting_round.value().currentVotingLine().value(),
 		std::string{ "(3/3) H: help. A: \'item2\'. B: \'item3\'. Your choice: " });
 }

--- a/src/test/test_generate_new_voting_round.cpp
+++ b/src/test/test_generate_new_voting_round.cpp
@@ -1,6 +1,6 @@
 #include "constants.h"
-#include "functions.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {

--- a/src/test/test_generate_voting_round_file_data.cpp
+++ b/src/test/test_generate_voting_round_file_data.cpp
@@ -1,6 +1,6 @@
-#include "functions.h"
 #include "helpers.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {
@@ -35,7 +35,7 @@ void votingRoundWithReducedVoting() {
 void votingRoundWithOneVote() {
 	auto voting_round = VotingRound::create({ "item1", "item2", "item3" }, false);
 	voting_round.value().shuffle();
-	vote(voting_round, Option::A);
+	voting_round.value().vote(Option::A);
 
 	auto const vote_string =
 		std::to_string(voting_round.value().votes[0].index_pair.first) + " " +

--- a/src/test/test_item_order_randomized.cpp
+++ b/src/test/test_item_order_randomized.cpp
@@ -1,5 +1,5 @@
-#include "functions.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {
@@ -102,7 +102,7 @@ void scoresAreCalculatedWithCorrectItems() {
 
 	// Vote A on each option
 	for (uint32_t i = 0; i < voting_round.value().numberOfScheduledVotes(); i++) {
-		vote(voting_round, Option::A);
+		voting_round.value().vote(Option::A);
 	}
 	auto const scores = voting_round.value().calculateScores();
 
@@ -118,7 +118,7 @@ void scoresAreCalculatedWithCorrectItems() {
 	}
 }
 
-}
+} // namespace
 
 int main() {
 	itemOrderIsShuffledWhenShufflingNewVotingRound();

--- a/src/test/test_load_and_save_file.cpp
+++ b/src/test/test_load_and_save_file.cpp
@@ -4,6 +4,7 @@
 #include "functions.h"
 #include "helpers.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {

--- a/src/test/test_parse_voting_round.cpp
+++ b/src/test/test_parse_voting_round.cpp
@@ -1,5 +1,5 @@
-#include "functions.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {

--- a/src/test/test_prune_votes.cpp
+++ b/src/test/test_prune_votes.cpp
@@ -1,7 +1,7 @@
 #include "constants.h"
-#include "functions.h"
 #include "helpers.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {
@@ -87,7 +87,7 @@ void pruningAmountAfterVotingRoundCreationDependsOnNumberOfItems() {
 }
 void pruningWhenVotesAlreadyExist() {
 	auto voting_round = VotingRound::create(getNItems(15), false);
-	vote(voting_round, Option::A);
+	voting_round.value().vote(Option::A);
 	voting_round.value().prune();
 	ASSERT_FALSE(voting_round.value().reduced_voting);
 	ASSERT_EQ(voting_round.value().numberOfScheduledVotes(), static_cast<uint32_t>(sumOfFirstIntegers(voting_round.value().items.size() - 1)));

--- a/src/test/test_shuffle_voting_order.cpp
+++ b/src/test/test_shuffle_voting_order.cpp
@@ -1,5 +1,5 @@
-#include "functions.h"
 #include "testing.h"
+#include "voting_round.h"
 
 int main() {
 	auto voting_round = VotingRound::create({ "1", "2", "3", "4", "5", "6", "7", "8" }, false);

--- a/src/test/test_verify_voting_round.cpp
+++ b/src/test/test_verify_voting_round.cpp
@@ -1,5 +1,5 @@
-#include "functions.h"
 #include "testing.h"
+#include "voting_round.h"
 
 namespace
 {
@@ -94,7 +94,7 @@ void votingRoundWithValidVotes() {
 	for (auto prune_votes : { true, false }) {
 		for (size_t number_of_items = 2; number_of_items < 25; number_of_items++) {
 			auto voting_round = VotingRound::create(getNItems(number_of_items), prune_votes);
-			vote(voting_round, Option::A);
+			voting_round.value().vote(Option::A);
 			ASSERT_TRUE(voting_round.value().verify());
 		}
 	}
@@ -104,7 +104,7 @@ void votingRoundWithCompletedVoting() {
 		for (size_t number_of_items = 2; number_of_items < 25; number_of_items++) {
 			auto voting_round = VotingRound::create(getNItems(number_of_items), prune_votes);
 			for (size_t i = 0; i < voting_round.value().numberOfScheduledVotes(); i++) {
-				vote(voting_round, static_cast<Option>(i % 2));
+				voting_round.value().vote(static_cast<Option>(i % 2));
 			}
 			ASSERT_TRUE(voting_round.value().verify());
 		}
@@ -115,7 +115,7 @@ void votingRoundWithTooManyVotes() {
 		for (uint32_t number_of_items = 2; number_of_items < 25; number_of_items++) {
 			auto voting_round = VotingRound::create(getNItems(number_of_items), prune_votes);
 			for (size_t i = 0; i < voting_round.value().numberOfScheduledVotes(); i++) {
-				vote(voting_round, static_cast<Option>(i % 2));
+				voting_round.value().vote(static_cast<Option>(i % 2));
 			}
 			voting_round.value().votes.emplace_back(IndexPair{ 0, number_of_items }, Option::A);
 			ASSERT_FALSE(voting_round.value().verify());
@@ -144,7 +144,7 @@ void votingRoundWithDuplicateVotes() {
 	for (auto prune_votes : { true, false }) {
 		for (size_t number_of_items = 3; number_of_items < 25; number_of_items++) {
 			auto voting_round = VotingRound::create(getNItems(number_of_items), prune_votes);
-			vote(voting_round, Option::B);
+			voting_round.value().vote(Option::B);
 			voting_round.value().votes.emplace_back(voting_round.value().votes[0].index_pair, Option::A);
 			ASSERT_FALSE(voting_round.value().verify());
 		}


### PR DESCRIPTION
Previous definition of test cases had them all include and depend on the same set of files, to simplify and loop test cases easily.
This meant any change to any part of the code logic would require all test cases to be rebuilt, wasting time and being a non-scalable design.

Now the necessary files are defined manually for each test case, increasing code bloat a little but reducing build times. Some addition planned code separation will further improve this.