### PR TITLE
Separate testing into suites and tests

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,52 +2,106 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_testing()
 
-set(test_name test_calculate_scores)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+function(addTestSuite suite_name file_dependencies test_cases)
+	add_executable(${suite_name}
+		${suite_name}.cpp
+		testing.cpp
+		${file_dependencies}
+	)
+	target_include_directories(${suite_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+	foreach (test_case ${test_cases})
+		add_test(NAME "${suite_name}/${test_case}" COMMAND ${suite_name} ${test_case})
+	endforeach()
+endfunction()
+
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/score.cpp
+)
+list(APPEND test_cases
+	zeroVotes
+	oneVoteForA
+	oneVoteForB
+	votingForItem2AndOptionAIfNotPresent
+	votingForItem3AndOptionAIfNotPresent
+	votingForItem2AndOptionBIfNotPresent
+	votingForItem3AndOptionBIfNotPresent
+	votingForItem2AndAgainstItem3AndOptionAIfNeither
+	votingForItem2AndAgainstItem3AndOptionBIfNeither
+	votingForItem3AndAgainstItem2AndOptionAIfNeither
+	votingForItem3AndAgainstItem2AndOptionBIfNeither
+	votingForOptionAButNotFullRound
+	votingForOptionBButNotFullRound
+	tooFewVotesToScoreAllItems
+)
+addTestSuite(test_calculate_scores "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_combine_scores)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
+)
+list(APPEND test_cases
+	combiningNoScoreSet
+	combiningOneScoreSetWithZeroScores
+	combiningOneScoreSetWithOneScore
+	combiningOneScoreSetWithMultipleScores
+	combiningTwoScoreSetsWhenOneScoreSetIsEmpty
+	combiningTwoScoreSetsWithSameItem
+	combiningTwoScoreSetsWithDifferentItems
+)
+addTestSuite(test_combine_scores "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_create_score_table)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
+)
+list(APPEND test_cases
+	noScores
+	alreadySorted
+	reversedOrder
+	winLossDifferenceIsZeroAndTotalIsDifferent
+	winLossDifferenceIsZeroAndTotalIsTheSame
+	winLossDifferenceIsEqualAndPositive
+	winLossDifferenceIsEqualAndNegative
+	shortItemNameAndWinsAndLosses
+	longItemNameAndWinsAndLosses
+)
+addTestSuite(test_create_score_table "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_current_voting_line)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	counterLengthEqualsTotalLength
+	counterLengthIsLessThanTotalLength
+	itemIsShorterThanLongestItem
+	itemLengthIsEqualToHeaderLength
+	votingIsCompleted
+	incompleteVotingIncreasesCounterAndChangesItem
+)
+addTestSuite(test_current_voting_line "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_e2e_voting_round)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
@@ -55,174 +109,304 @@ add_executable(${test_name}
 	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/vote.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	votingRoundIsTheSameAfterLoading
+	scoresAreTheSameDespiteDifferentItemOrderAndSeed
+)
+addTestSuite(test_e2e_voting_round "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_generate_new_voting_round)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/vote.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	generateWithTooFewItems
+	generateWithOnlyEmptyItems
+	generateWithSomeEmptyItems
+	generateWithFullVoting
+	generateWithReducedVotingIfTooFewItemsToReduce
+	generateWithReducedVotingIfEnoughItemsToReduce
+	generateWithFullVotingGivesCorrectAmountOfScheduledVotes
+	generateWithReducedVotingGivesCorrectAmountOfScheduledVotes
+	generateWithFullVotingGivesCorrectScheduledVotes
+)
+addTestSuite(test_generate_new_voting_round "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_generate_score_file_data)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
+)
+list(APPEND test_cases
+	noScores
+	oneScore
+	oneScoreWithSpacesInItemName
+	multipleScores
+)
+addTestSuite(test_generate_score_file_data "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_generate_voting_round_file_data)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	emptyVotingRound
+	votingRoundWithFullVoting
+	votingRoundWithReducedVoting
+	votingRoundWithOneVote
+)
+addTestSuite(test_generate_voting_round_file_data "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_get_active_menu_string)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/menus.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	showIntro
+	noVotingRoundCreated
+	votingRoundStarted
+	votingRoundCompleted
+)
+addTestSuite(test_get_active_menu_string "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_item_order_randomized)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/score.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	itemOrderIsShuffledWhenShufflingNewVotingRound
+	originalItemOrderIsRetainedWhenShufflingNewVotingRound
+	itemOrderIsShuffledWhenShufflingParsedVotingRound
+	originalItemOrderIsRetainedWhenShufflingParsedVotingRound
+	convertingVotingRoundToTextUsesOriginalItemOrder
+	scoresAreCalculatedWithCorrectItems
+)
+addTestSuite(test_item_order_randomized "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_load_and_save_file)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+)
+list(APPEND test_cases
+	savingAndLoadingLines
+	savingAndLoadingLinesWithEmptyLines
+	savingAndLoadingOnlyEmptyLines
+	savingNoLines
+	loadingNoLines
+	savingToExistingFile
+	loadingNonExistingFile
+)
+addTestSuite(test_load_and_save_file "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_parse_scores)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
+)
+list(APPEND test_cases
+	stringIsEmpty
+	stringIsValid
+	itemIsAnInteger
+	itemHasMultipleWords
+	itemHasIntegersAfterSpace
+	stringMissingWinsOrLosses
+	stringMissingItem
+	winsOrLossesAreNegative
+	winsOrLossesAreAfterItem
+	multipleItemsWithoutWinsOrLosses
+	noStringsSent
+	allStringsAreValid
+	onlyOneStringIsValid
+	validNumbers
+	nonNumbers
+)
+addTestSuite(test_parse_scores "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_parse_voting_round)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/vote.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	noLinesToParse
+	noItemsBeforeEmptyLine
+	fewerThanTwoItems
+	itemAppearsMultipleTimes
+	anItemIsEmpty
+	noEmptyLineBetweenItemsAndSeed
+	seedIsMissing
+	seedIsEmpty
+	seedIsNotAPositiveInteger
+	fullVoting
+	reducedVotingWithTooFewItems
+	reducedVotingWithEnoughItems
+	reducedVotingSettingIsMissing
+	reducedVotingSettingIsEmpty
+	reducedVotingSettingIsInvalid
+	noVotes
+	voteDoesNotHaveThreeIntegers
+	voteOptionIndicesAreGreaterThanNumberOfItems
+	moreVotesThanPossible
+	sameMatchupMultipleTimes
+	chosenVoteIsNotZeroOrOne
+	fourItemsAndReducedVotingAndFourVotes
+	fourItemsAndFullVotingAndOneVote
+	fourItemsAndFullVotingAndZeroVotes
+)
+addTestSuite(test_parse_voting_round "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_prune_votes)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/vote.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	pruningDuringVotingRoundCreationWithTooFewItems
+	pruningAmountDuringVotingRoundCreationDependsOnNumberOfItems
+	parseVotingRoundWithPruning
+	pruningRemovesCorrectScheduledVotes
+)
+addTestSuite(test_prune_votes "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_save_scores)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
+)
+list(APPEND test_cases
+	saveWhenNoScores
+	saveWhenSomeScores
+)
+addTestSuite(test_save_scores "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_save_votes)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	saveWhenSomeVotesRemain
+	saveWhenNoVotesRemain
+)
+addTestSuite(test_save_votes "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_shuffle_voting_order)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
 
-set(test_name test_undo)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
-
-set(test_name test_vote)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
+list(APPEND test_dependencies
 	${PROJECT_SOURCE_DIR}/src/helpers.cpp
 	${PROJECT_SOURCE_DIR}/src/print.cpp
 	${PROJECT_SOURCE_DIR}/src/vote.cpp
 	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	shufflingWithSeedIsDeterministic
+)
+addTestSuite(test_shuffle_voting_order "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
 
-set(test_name test_voting_format)
-add_executable(${test_name}
-	${test_name}.cpp
-	testing.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp)
-target_include_directories(${test_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-add_test(NAME ${test_name} COMMAND ${test_name})
+
+list(APPEND test_dependencies
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	undoWhenVotesExist
+	undoWhenNoVotesExist
+)
+addTestSuite(test_undo "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
+
+
+list(APPEND test_dependencies
+	${PROJECT_SOURCE_DIR}/src/helpers.cpp
+	${PROJECT_SOURCE_DIR}/src/print.cpp
+	${PROJECT_SOURCE_DIR}/src/vote.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
+	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
+)
+list(APPEND test_cases
+	firstVoteForA
+	firstVoteForB
+	votingForAForEachScheduledVote
+	votingForBForEachScheduledVote
+	votingAfterRoundCompleted
+)
+addTestSuite(test_vote "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)
+
+
+list(APPEND test_dependencies
+	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
+)
+list(APPEND test_cases
+	charToFormatWithValidOptions
+	charToFormatWithInvalidOptions
+	stringToFormatWithValidOptions
+	stringToFormatWithInalidOptions
+	formatToString
+)
+addTestSuite(test_voting_format "${test_dependencies}" "${test_cases}")
+unset(file_dependencies)
+unset(test_cases)

--- a/src/test/test_calculate_scores.cpp
+++ b/src/test/test_calculate_scores.cpp
@@ -270,20 +270,21 @@ void tooFewVotesToScoreAllItems() {
 
 } // namespace
 
-int main() {
-	zeroVotes();
-	oneVoteForA();
-	oneVoteForB();
-	votingForItem2AndOptionAIfNotPresent();
-	votingForItem3AndOptionAIfNotPresent();
-	votingForItem2AndOptionBIfNotPresent();
-	votingForItem3AndOptionBIfNotPresent();
-	votingForItem2AndAgainstItem3AndOptionAIfNeither();
-	votingForItem2AndAgainstItem3AndOptionBIfNeither();
-	votingForItem3AndAgainstItem2AndOptionAIfNeither();
-	votingForItem3AndAgainstItem2AndOptionBIfNeither();
-	votingForOptionAButNotFullRound();
-	votingForOptionBButNotFullRound();
-	tooFewVotesToScoreAllItems();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(zeroVotes);
+	RUN_TEST_IF_ARGUMENT_EQUALS(oneVoteForA);
+	RUN_TEST_IF_ARGUMENT_EQUALS(oneVoteForB);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem2AndOptionAIfNotPresent);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem3AndOptionAIfNotPresent);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem2AndOptionBIfNotPresent);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem3AndOptionBIfNotPresent);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem2AndAgainstItem3AndOptionAIfNeither);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem2AndAgainstItem3AndOptionBIfNeither);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem3AndAgainstItem2AndOptionAIfNeither);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForItem3AndAgainstItem2AndOptionBIfNeither);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForOptionAButNotFullRound);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForOptionBButNotFullRound);
+	RUN_TEST_IF_ARGUMENT_EQUALS(tooFewVotesToScoreAllItems);
 	return 0;
 }

--- a/src/test/test_combine_scores.cpp
+++ b/src/test/test_combine_scores.cpp
@@ -48,13 +48,14 @@ void combiningTwoScoreSetsWithDifferentItems() {
 
 } // namespace
 
-int main() {
-	combiningNoScoreSet();
-	combiningOneScoreSetWithZeroScores();
-	combiningOneScoreSetWithOneScore();
-	combiningOneScoreSetWithMultipleScores();
-	combiningTwoScoreSetsWhenOneScoreSetIsEmpty();
-	combiningTwoScoreSetsWithSameItem();
-	combiningTwoScoreSetsWithDifferentItems();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(combiningNoScoreSet);
+	RUN_TEST_IF_ARGUMENT_EQUALS(combiningOneScoreSetWithZeroScores);
+	RUN_TEST_IF_ARGUMENT_EQUALS(combiningOneScoreSetWithOneScore);
+	RUN_TEST_IF_ARGUMENT_EQUALS(combiningOneScoreSetWithMultipleScores);
+	RUN_TEST_IF_ARGUMENT_EQUALS(combiningTwoScoreSetsWhenOneScoreSetIsEmpty);
+	RUN_TEST_IF_ARGUMENT_EQUALS(combiningTwoScoreSetsWithSameItem);
+	RUN_TEST_IF_ARGUMENT_EQUALS(combiningTwoScoreSetsWithDifferentItems);
 	return 0;
 }

--- a/src/test/test_create_score_table.cpp
+++ b/src/test/test_create_score_table.cpp
@@ -118,15 +118,16 @@ void longItemNameAndWinsAndLosses() {
 
 } // namespace
 
-int main() {
-	noScores();
-	alreadySorted();
-	reversedOrder();
-	winLossDifferenceIsZeroAndTotalIsDifferent();
-	winLossDifferenceIsZeroAndTotalIsTheSame();
-	winLossDifferenceIsEqualAndPositive();
-	winLossDifferenceIsEqualAndNegative();
-	shortItemNameAndWinsAndLosses();
-	longItemNameAndWinsAndLosses();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noScores);
+	RUN_TEST_IF_ARGUMENT_EQUALS(alreadySorted);
+	RUN_TEST_IF_ARGUMENT_EQUALS(reversedOrder);
+	RUN_TEST_IF_ARGUMENT_EQUALS(winLossDifferenceIsZeroAndTotalIsDifferent);
+	RUN_TEST_IF_ARGUMENT_EQUALS(winLossDifferenceIsZeroAndTotalIsTheSame);
+	RUN_TEST_IF_ARGUMENT_EQUALS(winLossDifferenceIsEqualAndPositive);
+	RUN_TEST_IF_ARGUMENT_EQUALS(winLossDifferenceIsEqualAndNegative);
+	RUN_TEST_IF_ARGUMENT_EQUALS(shortItemNameAndWinsAndLosses);
+	RUN_TEST_IF_ARGUMENT_EQUALS(longItemNameAndWinsAndLosses);
 	return 0;
 }

--- a/src/test/test_current_voting_line.cpp
+++ b/src/test/test_current_voting_line.cpp
@@ -61,12 +61,13 @@ void incompleteVotingIncreasesCounterAndChangesItem() {
 
 } // namespace
 
-int main() {
-	counterLengthEqualsTotalLength();
-	counterLengthIsLessThanTotalLength();
-	itemIsShorterThanLongestItem();
-	itemLengthIsEqualToHeaderLength();
-	votingIsCompleted();
-	incompleteVotingIncreasesCounterAndChangesItem();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(counterLengthEqualsTotalLength);
+	RUN_TEST_IF_ARGUMENT_EQUALS(counterLengthIsLessThanTotalLength);
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemIsShorterThanLongestItem);
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemLengthIsEqualToHeaderLength);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingIsCompleted);
+	RUN_TEST_IF_ARGUMENT_EQUALS(incompleteVotingIncreasesCounterAndChangesItem);
 	return 0;
 }

--- a/src/test/test_e2e_voting_round.cpp
+++ b/src/test/test_e2e_voting_round.cpp
@@ -128,8 +128,9 @@ void scoresAreTheSameDespiteDifferentItemOrderAndSeed() {
 
 } // namespace
 
-int main() {
-	votingRoundIsTheSameAfterLoading();
-	scoresAreTheSameDespiteDifferentItemOrderAndSeed();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundIsTheSameAfterLoading);
+	RUN_TEST_IF_ARGUMENT_EQUALS(scoresAreTheSameDespiteDifferentItemOrderAndSeed);
 	return 0;
 }

--- a/src/test/test_generate_new_voting_round.cpp
+++ b/src/test/test_generate_new_voting_round.cpp
@@ -375,16 +375,17 @@ void generateWithFullVotingGivesCorrectScheduledVotes() {
 
 } // namespace
 
-int main() {
-	generateWithTooFewItems();
-	generateWithOnlyEmptyItems();
-	generateWithSomeEmptyItems();
-	generateWithFullVoting();
-	generateWithReducedVotingIfTooFewItemsToReduce();
-	generateWithReducedVotingIfEnoughItemsToReduce();
-	generateWithFullVotingGivesCorrectAmountOfScheduledVotes();
-	generateWithReducedVotingGivesCorrectAmountOfScheduledVotes();
-	generateWithFullVotingGivesCorrectScheduledVotes();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithTooFewItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithOnlyEmptyItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithSomeEmptyItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithFullVoting);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithReducedVotingIfTooFewItemsToReduce);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithReducedVotingIfEnoughItemsToReduce);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithFullVotingGivesCorrectAmountOfScheduledVotes);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithReducedVotingGivesCorrectAmountOfScheduledVotes);
+	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithFullVotingGivesCorrectScheduledVotes);
 
 	return 0;
 }

--- a/src/test/test_generate_score_file_data.cpp
+++ b/src/test/test_generate_score_file_data.cpp
@@ -1,18 +1,36 @@
 #include "testing.h"
 #include "score_helpers.h"
 
-int main() {
+namespace
+{
+
+void noScores() {
 	ASSERT_EQ(generateScoreFileData({}), std::vector<std::string>{});
-	ASSERT_EQ(generateScoreFileData({ Score{ "item1", 3, 6 }}), std::vector<std::string>{
+}
+void oneScore() {
+	ASSERT_EQ(generateScoreFileData({ Score{ "item1", 3, 6 } }), std::vector<std::string>{
 		"3 6 item1"
 	});
+}
+void oneScoreWithSpacesInItemName() {
 	ASSERT_EQ(generateScoreFileData({ Score{ "item with space", 3, 6 } }), std::vector<std::string>{
 		"3 6 item with space"
 	});
+}
+void multipleScores() {
 	ASSERT_EQ(generateScoreFileData({ Score{ "item1", 3, 6 }, Score{ "item2", 71, 4 } }), std::vector<std::string>{
 		"3 6 item1",
-		"71 4 item2"
+			"71 4 item2"
 	});
+}
 
+} // namespace
+
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noScores);
+	RUN_TEST_IF_ARGUMENT_EQUALS(oneScore);
+	RUN_TEST_IF_ARGUMENT_EQUALS(oneScoreWithSpacesInItemName);
+	RUN_TEST_IF_ARGUMENT_EQUALS(multipleScores);
 	return 0;
 }

--- a/src/test/test_generate_voting_round_file_data.cpp
+++ b/src/test/test_generate_voting_round_file_data.cpp
@@ -54,10 +54,11 @@ void votingRoundWithOneVote() {
 
 } // namespace
 
-int main() {
-	emptyVotingRound();
-	votingRoundWithFullVoting();
-	votingRoundWithReducedVoting();
-	votingRoundWithOneVote();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(emptyVotingRound);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundWithFullVoting);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundWithReducedVoting);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundWithOneVote);
 	return 0;
 }

--- a/src/test/test_get_active_menu_string.cpp
+++ b/src/test/test_get_active_menu_string.cpp
@@ -26,10 +26,11 @@ void votingRoundCompleted() {
 
 } // namespace
 
-int main() {
-	showIntro();
-	noVotingRoundCreated();
-	votingRoundStarted();
-	votingRoundCompleted();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(showIntro);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noVotingRoundCreated);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundStarted);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundCompleted);
 	return 0;
 }

--- a/src/test/test_item_order_randomized.cpp
+++ b/src/test/test_item_order_randomized.cpp
@@ -104,13 +104,15 @@ void scoresAreCalculatedWithCorrectItems() {
 
 } // namespace
 
-int main() {
-	itemOrderIsShuffledWhenShufflingNewVotingRound();
-	originalItemOrderIsRetainedWhenShufflingNewVotingRound();
-	itemOrderIsShuffledWhenShufflingParsedVotingRound();
-	originalItemOrderIsRetainedWhenShufflingParsedVotingRound();
-	convertingVotingRoundToTextUsesOriginalItemOrder();
-	scoresAreCalculatedWithCorrectItems();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemOrderIsShuffledWhenShufflingNewVotingRound);
+	RUN_TEST_IF_ARGUMENT_EQUALS(originalItemOrderIsRetainedWhenShufflingNewVotingRound);
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemOrderIsShuffledWhenShufflingParsedVotingRound);
+	RUN_TEST_IF_ARGUMENT_EQUALS(originalItemOrderIsRetainedWhenShufflingParsedVotingRound);
+	RUN_TEST_IF_ARGUMENT_EQUALS(convertingVotingRoundToTextUsesOriginalItemOrder);
+	RUN_TEST_IF_ARGUMENT_EQUALS(scoresAreCalculatedWithCorrectItems);
 
 	return 0;
 }

--- a/src/test/test_load_and_save_file.cpp
+++ b/src/test/test_load_and_save_file.cpp
@@ -78,16 +78,17 @@ void loadingNonExistingFile() {
 
 } // namespace
 
-int main() {
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
 	std::filesystem::remove(kTestFileName);
 
-	savingAndLoadingLines();
-	savingAndLoadingLinesWithEmptyLines();
-	savingAndLoadingOnlyEmptyLines();
-	savingNoLines();
-	loadingNoLines();
-	savingToExistingFile();
-	loadingNonExistingFile();
+	RUN_TEST_IF_ARGUMENT_EQUALS(savingAndLoadingLines);
+	RUN_TEST_IF_ARGUMENT_EQUALS(savingAndLoadingLinesWithEmptyLines);
+	RUN_TEST_IF_ARGUMENT_EQUALS(savingAndLoadingOnlyEmptyLines);
+	RUN_TEST_IF_ARGUMENT_EQUALS(savingNoLines);
+	RUN_TEST_IF_ARGUMENT_EQUALS(loadingNoLines);
+	RUN_TEST_IF_ARGUMENT_EQUALS(savingToExistingFile);
+	RUN_TEST_IF_ARGUMENT_EQUALS(loadingNonExistingFile);
 
 	std::filesystem::remove(kTestFileName);
 	return 0;

--- a/src/test/test_parse_scores.cpp
+++ b/src/test/test_parse_scores.cpp
@@ -98,21 +98,25 @@ void nonNumbers() {
 }
 } // namespace
 
-int main() {
-	stringIsEmpty();
-	stringIsValid();
-	itemIsAnInteger();
-	itemHasMultipleWords();
-	itemHasIntegersAfterSpace();
-	stringMissingWinsOrLosses();
-	stringMissingItem();
-	winsOrLossesAreNegative();
-	winsOrLossesAreAfterItem();
-	multipleItemsWithoutWinsOrLosses();
-	noStringsSent();
-	allStringsAreValid();
-	onlyOneStringIsValid();
-	validNumbers();
-	nonNumbers();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+
+	RUN_TEST_IF_ARGUMENT_EQUALS(stringIsEmpty);
+	RUN_TEST_IF_ARGUMENT_EQUALS(stringIsEmpty);
+	RUN_TEST_IF_ARGUMENT_EQUALS(stringIsValid);
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemIsAnInteger);
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemHasMultipleWords);
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemHasIntegersAfterSpace);
+	RUN_TEST_IF_ARGUMENT_EQUALS(stringMissingWinsOrLosses);
+	RUN_TEST_IF_ARGUMENT_EQUALS(stringMissingItem);
+	RUN_TEST_IF_ARGUMENT_EQUALS(winsOrLossesAreNegative);
+	RUN_TEST_IF_ARGUMENT_EQUALS(winsOrLossesAreAfterItem);
+	RUN_TEST_IF_ARGUMENT_EQUALS(multipleItemsWithoutWinsOrLosses);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noStringsSent);
+	RUN_TEST_IF_ARGUMENT_EQUALS(allStringsAreValid);
+	RUN_TEST_IF_ARGUMENT_EQUALS(onlyOneStringIsValid);
+	RUN_TEST_IF_ARGUMENT_EQUALS(validNumbers);
+	RUN_TEST_IF_ARGUMENT_EQUALS(nonNumbers);
+
 	return 0;
 }

--- a/src/test/test_parse_voting_round.cpp
+++ b/src/test/test_parse_voting_round.cpp
@@ -405,32 +405,32 @@ void fourItemsAndFullVotingAndZeroVotes() {
 
 } // namespace
 
-int main() {
-	noLinesToParse();
-	noItemsBeforeEmptyLine();
-	fewerThanTwoItems();
-	itemAppearsMultipleTimes();
-	anItemIsEmpty();
-	noEmptyLineBetweenItemsAndSeed();
-	seedIsMissing();
-	seedIsEmpty();
-	seedIsNotAPositiveInteger();
-	fullVoting();
-	reducedVotingWithTooFewItems();
-	reducedVotingWithEnoughItems();
-	reducedVotingSettingIsMissing();
-	reducedVotingSettingIsEmpty();
-	reducedVotingSettingIsInvalid();
-	noVotes();
-	voteDoesNotHaveThreeIntegers();
-	chosenVoteIsNotZeroOrOne();
-	voteOptionIndicesAreGreaterThanNumberOfItems();
-	moreVotesThanPossible();
-	sameMatchupMultipleTimes();
-	chosenVoteIsNotZeroOrOne();
-	fourItemsAndReducedVotingAndFourVotes();
-	fourItemsAndFullVotingAndOneVote();
-	fourItemsAndFullVotingAndZeroVotes();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noLinesToParse);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noItemsBeforeEmptyLine);
+	RUN_TEST_IF_ARGUMENT_EQUALS(fewerThanTwoItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(itemAppearsMultipleTimes);
+	RUN_TEST_IF_ARGUMENT_EQUALS(anItemIsEmpty);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noEmptyLineBetweenItemsAndSeed);
+	RUN_TEST_IF_ARGUMENT_EQUALS(seedIsMissing);
+	RUN_TEST_IF_ARGUMENT_EQUALS(seedIsEmpty);
+	RUN_TEST_IF_ARGUMENT_EQUALS(seedIsNotAPositiveInteger);
+	RUN_TEST_IF_ARGUMENT_EQUALS(fullVoting);
+	RUN_TEST_IF_ARGUMENT_EQUALS(reducedVotingWithTooFewItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(reducedVotingWithEnoughItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(reducedVotingSettingIsMissing);
+	RUN_TEST_IF_ARGUMENT_EQUALS(reducedVotingSettingIsEmpty);
+	RUN_TEST_IF_ARGUMENT_EQUALS(reducedVotingSettingIsInvalid);
+	RUN_TEST_IF_ARGUMENT_EQUALS(noVotes);
+	RUN_TEST_IF_ARGUMENT_EQUALS(voteDoesNotHaveThreeIntegers);
+	RUN_TEST_IF_ARGUMENT_EQUALS(voteOptionIndicesAreGreaterThanNumberOfItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(moreVotesThanPossible);
+	RUN_TEST_IF_ARGUMENT_EQUALS(sameMatchupMultipleTimes);
+	RUN_TEST_IF_ARGUMENT_EQUALS(chosenVoteIsNotZeroOrOne);
+	RUN_TEST_IF_ARGUMENT_EQUALS(fourItemsAndReducedVotingAndFourVotes);
+	RUN_TEST_IF_ARGUMENT_EQUALS(fourItemsAndFullVotingAndOneVote);
+	RUN_TEST_IF_ARGUMENT_EQUALS(fourItemsAndFullVotingAndZeroVotes);
 
 	return 0;
 }

--- a/src/test/test_prune_votes.cpp
+++ b/src/test/test_prune_votes.cpp
@@ -210,10 +210,11 @@ void pruningRemovesCorrectScheduledVotes() {
 
 } // namsepace
 
-int main() {
-	pruningDuringVotingRoundCreationWithTooFewItems();
-	pruningAmountDuringVotingRoundCreationDependsOnNumberOfItems();
-	parseVotingRoundWithPruning();
-	pruningRemovesCorrectScheduledVotes();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(pruningDuringVotingRoundCreationWithTooFewItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(pruningAmountDuringVotingRoundCreationDependsOnNumberOfItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(parseVotingRoundWithPruning);
+	RUN_TEST_IF_ARGUMENT_EQUALS(pruningRemovesCorrectScheduledVotes);
 	return 0;
 }

--- a/src/test/test_save_scores.cpp
+++ b/src/test/test_save_scores.cpp
@@ -27,11 +27,12 @@ void saveWhenSomeScores() {
 
 } // namespace
 
-int main() {
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
 	std::filesystem::remove(kTestFileName);
 
-	saveWhenNoScores();
-	saveWhenSomeScores();
+	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenNoScores);
+	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenSomeScores);
 
 	std::filesystem::remove(kTestFileName);
 	return 0;

--- a/src/test/test_save_votes.cpp
+++ b/src/test/test_save_votes.cpp
@@ -36,11 +36,12 @@ void saveWhenNoVotesRemain() {
 
 } // namespace
 
-int main() {
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
 	std::filesystem::remove(kTestFileName);
 
-	saveWhenSomeVotesRemain();
-	saveWhenNoVotesRemain();
+	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenSomeVotesRemain);
+	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenNoVotesRemain);
 
 	std::filesystem::remove(kTestFileName);
 	return 0;

--- a/src/test/test_shuffle_voting_order.cpp
+++ b/src/test/test_shuffle_voting_order.cpp
@@ -1,7 +1,10 @@
 #include "testing.h"
 #include "voting_round.h"
 
-int main() {
+namespace
+{
+
+void shufflingWithSeedIsDeterministic() {
 	auto voting_round = VotingRound::create(getNItems(8), VotingFormat::Full, 123456);
 	voting_round.value().shuffle();
 
@@ -36,6 +39,12 @@ int main() {
 		Vote{1, 3, Option::A},
 		Vote{1, 5, Option::A},
 		Vote{1, 7, Option::A} });
+}
 
+} // namespace
+
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(shufflingWithSeedIsDeterministic);
 	return 0;
 }

--- a/src/test/test_undo.cpp
+++ b/src/test/test_undo.cpp
@@ -19,8 +19,9 @@ void undoWhenNoVotesExist() {
 
 } // namespace
 
-int main() {
-	undoWhenVotesExist();
-	undoWhenNoVotesExist();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(undoWhenVotesExist);
+	RUN_TEST_IF_ARGUMENT_EQUALS(undoWhenNoVotesExist);
 	return 0;
 }

--- a/src/test/test_vote.cpp
+++ b/src/test/test_vote.cpp
@@ -60,11 +60,12 @@ void votingAfterRoundCompleted() {
 
 } // namespace
 
-int main() {
-	firstVoteForA();
-	firstVoteForB();
-	votingForAForEachScheduledVote();
-	votingForBForEachScheduledVote();
-	votingAfterRoundCompleted();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(firstVoteForA);
+	RUN_TEST_IF_ARGUMENT_EQUALS(firstVoteForB);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForAForEachScheduledVote);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingForBForEachScheduledVote);
+	RUN_TEST_IF_ARGUMENT_EQUALS(votingAfterRoundCompleted);
 	return 0;
 }

--- a/src/test/test_voting_format.cpp
+++ b/src/test/test_voting_format.cpp
@@ -36,11 +36,12 @@ void formatToString() {
 
 } // namespace
 
-int main() {
-	charToFormatWithValidOptions();
-	charToFormatWithInvalidOptions();
-	stringToFormatWithValidOptions();
-	stringToFormatWithInalidOptions();
-	formatToString();
+int main(int argc, char* argv[]) {
+	ASSERT_EQ(argc, 2);
+	RUN_TEST_IF_ARGUMENT_EQUALS(charToFormatWithValidOptions);
+	RUN_TEST_IF_ARGUMENT_EQUALS(charToFormatWithInvalidOptions);
+	RUN_TEST_IF_ARGUMENT_EQUALS(stringToFormatWithValidOptions);
+	RUN_TEST_IF_ARGUMENT_EQUALS(stringToFormatWithInalidOptions);
+	RUN_TEST_IF_ARGUMENT_EQUALS(formatToString);
 	return 0;
 }

--- a/src/test/testing.h
+++ b/src/test/testing.h
@@ -5,6 +5,10 @@
 #include <string>
 #include <vector>
 
+/* -------------- Test definitions -------------- */
+#define RUN_TEST_IF_ARGUMENT_EQUALS(test_name) if (std::string{ argv[1] } == #test_name) { test_name(); return 0; }
+
+/* -------------- Assertions details -------------- */
 void assert_true(std::source_location const& location, bool val);
 
 template<typename T>
@@ -52,6 +56,7 @@ void assert_ne(std::source_location const& location, std::optional<T> const& a, 
 void assert_eq(std::source_location const& location, std::nullopt_t const& a, std::nullopt_t const& b);
 void assert_ne(std::source_location const& location, std::nullopt_t const& a, std::nullopt_t const& b);
 
+/* -------------- Assertions to use in tests -------------- */
 template<typename A, typename B>
 void ASSERT_EQ(A const& a, B const& b, std::source_location const location = std::source_location::current()) {
 	assert_eq(location, a, b);
@@ -60,42 +65,10 @@ template<typename T>
 void ASSERT_NE(T const& a, T const& b, std::source_location const location = std::source_location::current()) {
 	assert_ne(location, a, b);
 }
-
 void ASSERT_TRUE(bool a, std::source_location const location = std::source_location::current());
 void ASSERT_FALSE(bool a, std::source_location const location = std::source_location::current());
 
-#if false
-class BaseTest {
-public:
-	virtual void test() const = 0;
-};
-
-template<typename T>
-class TypedBaseTest : public BaseTest {
-public:
-	void test() const override {
-		constexpr size_t kOmitHeadLength = 6;
-		std::cout << std::string(typeid(T).name()).substr(kOmitHeadLength) << std::endl;
-		test_impl();
-	}
-protected:
-	virtual void test_impl() const = 0;
-};
-
-#define TEST(name) class name : public TypedBaseTest<name> { \
-protected: \
-	void test_impl() const override; \
-}; \
-void name::test_impl() const
-
-template<typename ... T>
-void run_tests() {
-	std::tuple<T...> tests;
-
-	std::apply([](auto&&... args) { (args.test(), ...); }, tests);
-}
-#endif
-
+/* -------------- Test helpers -------------- */
 template<typename T>
 auto operator+(std::vector<T> const& vec, T&& str) -> decltype(auto) {
 	auto new_vec = vec;


### PR DESCRIPTION
Since CTest "requires" one executable per test suite, the previous testing structure had 20 suites representing one test each, but with multiple functions in each suite to represent individual test scenarios.

With this change, there is still one executable per test suite, but the test scenarios are converted to one Ctest test each. This is done by passing the name of the test scenario as a command line argument to the corresponding test suite, evaluating that argument inside the test suite, and run only the corresponding scenario.

This doesn't increase test coverage, but does give more granularity in tests: Going from 20 tests to 132, It should also remove the test sequence ordering, as the previous structure didn't run any more test scenarios within a given suite if an earlier scenario fails.