### PR TITLE
Add end-to-end test for combining scores

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,9 +1,7 @@
 #include "functions.h"
 
 #include <conio.h>			// _getch()
-#include <filesystem>		// filesystem::current_path(), filesystem::exists()
 #include <fstream>			// ifstream
-#include <iostream>			// getline(), cin
 #include <unordered_set>	// unordered_set
 #include <sstream>			// stringstream
 
@@ -54,36 +52,6 @@ auto parseItems(std::vector<std::string> const& lines) -> Items {
 		items.emplace_back(fixSwedish(line));
 	}
 	return items;
-}
-auto getLine() -> std::string {
-	std::string input{};
-	std::getline(std::cin, input);
-	return input;
-}
-auto verifyFilesExist(std::vector<std::string> const& file_names) -> bool {
-	bool all_files_exist = true;
-	for (auto const& name : file_names) {
-		if (!std::filesystem::exists(name)) {
-			printError("File " + name + " doesn't exist");
-			all_files_exist = false;
-		}
-	}
-	return all_files_exist;
-}
-auto getMultipleFileNames() -> std::vector<std::string> {
-	print("Specify two or more files, e.g. \"file_1.txt file_2.txt\", without the quotation marks (\"): ", false);
-
-	std::vector<std::string> file_names = parseWords(getLine());
-	if (!verifyFilesExist(file_names)) {
-		printError("One or more files don't exist");
-		return {};
-	}
-
-	if (file_names.size() < 2) {
-		printError("Two or more files are required to combine scores");
-		return {};
-	}
-	return file_names;
 }
 
 } // namespace
@@ -163,39 +131,4 @@ void printScores(std::optional<VotingRound> const& voting_round) {
 		return;
 	}
 	print(createScoreTable(calculateScores(voting_round.value().items(), voting_round.value().votes())), false);
-}
-void combine() {
-	// Input names of two or more files to combine
-	//		Verify files exist
-	//		Allow cancelling
-	// Load lines for each file name
-	// Parse scores from lines
-	//		Identify the files which contain scores
-	//			For those that don't, print an error
-	// If there are two or more valid sets of scores, proceed
-	// Combine scores
-	// Return combined scores
-
-	// Get valid file names
-	std::vector<std::string> file_names = getMultipleFileNames();
-	if (file_names.size() < 2) {
-		printError("Too few files. No scores combined");
-		return;
-	}
-
-	// Load files' contents
-	std::vector<Scores> scores_sets{};
-
-	for (auto const& file_name : file_names) {
-		print("Reading " + file_name);
-		auto const lines = loadFile(file_name);
-		scores_sets.emplace_back(parseScores(lines));
-	}
-
-	Scores const combined_scores = combineScores(scores_sets);
-
-	if (!saveFile(kCombinedScoresFile, generateScoreFileData(sortScores(combined_scores)))) {
-		printError("Couldn't save file \'" + kCombinedScoresFile + "\'");
-	}
-	print("Saved combined scores to \'" + kCombinedScoresFile + "\'");
 }

--- a/src/functions.h
+++ b/src/functions.h
@@ -11,4 +11,3 @@ auto continueWithoutSaving(std::optional<VotingRound> const& voting_round, std::
 void newRound(std::optional<VotingRound>& voting_round);
 void loadRound(std::optional<VotingRound>& voting_round, std::vector<std::string> const& lines);
 void printScores(std::optional<VotingRound> const& voting_round);
-void combine();

--- a/src/pairwise_ranking.cpp
+++ b/src/pairwise_ranking.cpp
@@ -1,4 +1,5 @@
 ﻿#include <clocale>
+#include <iostream>
 #include <optional>
 #include <string>
 #include <vector>
@@ -10,6 +11,12 @@
 #include "menus.h"
 #include "print.h"
 #include "score_helpers.h"
+
+auto getLine() -> std::string {
+	std::string input{};
+	std::getline(std::cin, input);
+	return input;
+}
 
 void programLoop() {
 	std::optional<VotingRound> voting_round{};
@@ -93,7 +100,14 @@ void programLoop() {
 			voting_round.value().undoVote();
 		}
 		else if (ch == 'c') {
-			combine();
+			print("Specify two or more files, e.g. \"file_1.txt file_2.txt\", without the quotation marks (\"): ", false);
+			auto const input_line = getLine();
+			if (input_line.empty()) {
+				continue;
+			}
+			if (!combine(input_line, kCombinedScoresFile)) {
+				printError("Failed to combine scores");
+			}
 		}
 		else {
 			printError("Invalid input");

--- a/src/score_helpers.h
+++ b/src/score_helpers.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "score.h"
 
 /* -------------- Print scores -------------- */
@@ -13,6 +16,7 @@ auto createScoreTable(Scores const& scores) -> std::string;
 void addScore(Scores& scores, Score const& new_score);
 auto addScores(Scores const& a, Scores const& b) -> Scores;
 auto combineScores(std::vector<Scores> const& score_sets) -> Scores;
+auto combine(std::string const& file_names_line, std::string const& combined_score_file_name) -> bool;
 
 /* -------------- Score conversion -------------- */
 auto parseScore(std::string const& str) -> Score;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -54,6 +54,12 @@ list(APPEND test_cases
 	combiningTwoScoreSetsWhenOneScoreSetIsEmpty
 	combiningTwoScoreSetsWithSameItem
 	combiningTwoScoreSetsWithDifferentItems
+	endToEnd_combineFromTwoFiles
+	endToEnd_combineFromThreeFiles
+	endToEnd_combineFromTooFewFiles
+	endToEnd_combineFromInvalidFileName
+	endToEnd_combineFromAllEmptyFiles
+	endToEnd_combineFromOneEmptyFile
 )
 addTestSuite(test_combine_scores "${test_dependencies}" "${test_cases}")
 unset(file_dependencies)

--- a/src/test/test_combine_scores.cpp
+++ b/src/test/test_combine_scores.cpp
@@ -1,3 +1,7 @@
+#include <filesystem>
+#include <fstream>
+
+#include "helpers.h"
 #include "testing.h"
 #include "score_helpers.h"
 
@@ -45,6 +49,127 @@ void combiningTwoScoreSetsWithDifferentItems() {
 	ASSERT_EQ(combined_scores[0], score1);
 	ASSERT_EQ(combined_scores[1], score2);
 }
+void endToEnd_combineFromTwoFiles() {
+	constexpr char const* kScoresFile1 = "scores_1.txt";
+	constexpr char const* kScoresFile2 = "scores_2.txt";
+	constexpr char const* kCombinedFile = "combined_scores.txt";
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kCombinedFile);
+
+	ASSERT_TRUE(saveScores({ { "item1", 3, 0 }, { "item2", 2, 1 }, { "item3", 1, 2 }, { "item4", 0, 3 } }, kScoresFile1));
+	ASSERT_TRUE(saveScores({ { "item1", 1, 2 }, { "item2", 0, 3 }, { "item3", 3, 0 }, { "item4", 2, 1 } }, kScoresFile2));
+
+	ASSERT_TRUE(combine(std::string{ kScoresFile1 } + ' ' + kScoresFile2, kCombinedFile));
+	ASSERT_TRUE(std::filesystem::exists(kCombinedFile));
+
+	Scores const combined_scores = parseScores(loadFile(kCombinedFile));
+	ASSERT_EQ(combined_scores, Scores{ { "item1", 4, 2 }, { "item3", 4, 2 }, { "item2", 2, 4 }, { "item4", 2, 4 } });
+
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kCombinedFile);
+}
+void endToEnd_combineFromThreeFiles() {
+	constexpr char const* kScoresFile1 = "scores_1.txt";
+	constexpr char const* kScoresFile2 = "scores_2.txt";
+	constexpr char const* kScoresFile3 = "scores_3.txt";
+	constexpr char const* kCombinedFile = "combined_scores.txt";
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kScoresFile3);
+	std::filesystem::remove(kCombinedFile);
+
+	ASSERT_TRUE(saveScores({ { "item1", 3, 0 }, { "item2", 2, 1 }, { "item3", 1, 2 }, { "item4", 0, 3 } }, kScoresFile1));
+	ASSERT_TRUE(saveScores({ { "item1", 1, 2 }, { "item2", 0, 3 }, { "item3", 3, 0 }, { "item4", 2, 1 } }, kScoresFile2));
+	ASSERT_TRUE(saveScores({ { "item2", 2, 1 }, { "item4", 3, 0 }, { "item5", 1, 2 }, { "item6", 0, 3 } }, kScoresFile3));
+
+	ASSERT_TRUE(combine(std::string{ kScoresFile1 } + ' ' + kScoresFile2 + ' ' + kScoresFile3, kCombinedFile));
+	ASSERT_TRUE(std::filesystem::exists(kCombinedFile));
+
+	Scores const combined_scores = parseScores(loadFile(kCombinedFile));
+	ASSERT_EQ(combined_scores, Scores{ { "item1", 4, 2 }, { "item3", 4, 2 }, { "item4", 5, 4 }, { "item2", 4, 5 }, { "item5", 1, 2 }, { "item6", 0, 3 } });
+
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kScoresFile3);
+	std::filesystem::remove(kCombinedFile);
+}
+void endToEnd_combineFromTooFewFiles() {
+	constexpr char const* kScoresFile1 = "scores_1.txt";
+	constexpr char const* kCombinedFile = "combined_scores.txt";
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kCombinedFile);
+
+	ASSERT_TRUE(saveScores({ { "item1", 3, 0 }, { "item2", 2, 1 }, { "item3", 1, 2 }, { "item4", 0, 3 } }, kScoresFile1));
+
+	ASSERT_FALSE(combine(std::string{ kScoresFile1 }, kCombinedFile));
+	ASSERT_FALSE(std::filesystem::exists(kCombinedFile));
+
+	std::filesystem::remove(kScoresFile1);
+}
+void endToEnd_combineFromInvalidFileName() {
+	constexpr char const* kScoresFile1 = "scores_1.txt";
+	constexpr char const* kScoresFile2 = "scores_2.txt";
+	constexpr char const* kScoresFile3 = "scores_3.txt";
+	constexpr char const* kCombinedFile = "combined_scores.txt";
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kScoresFile3);
+	std::filesystem::remove(kCombinedFile);
+
+	ASSERT_TRUE(saveScores({ { "item1", 3, 0 }, { "item2", 2, 1 }, { "item3", 1, 2 }, { "item4", 0, 3 } }, kScoresFile1));
+	ASSERT_TRUE(saveScores({ { "item1", 1, 2 }, { "item2", 0, 3 }, { "item3", 3, 0 }, { "item4", 2, 1 } }, kScoresFile2));
+	ASSERT_TRUE(saveScores({ { "item2", 2, 1 }, { "item4", 3, 0 }, { "item5", 1, 2 }, { "item6", 0, 3 } }, kScoresFile3));
+
+	ASSERT_FALSE(combine(std::string{ kScoresFile1 } + " invalid_name.txt " + kScoresFile3, kCombinedFile));
+	ASSERT_FALSE(std::filesystem::exists(kCombinedFile));
+
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kScoresFile3);
+}
+void endToEnd_combineFromAllEmptyFiles() {
+	constexpr char const* kScoresFile1 = "scores_1.txt";
+	constexpr char const* kScoresFile2 = "scores_2.txt";
+	constexpr char const* kCombinedFile = "combined_scores.txt";
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kCombinedFile);
+
+	std::ofstream file1(kScoresFile1);
+	file1.close();
+	std::ofstream file2(kScoresFile2);
+	file2.close();
+
+	ASSERT_FALSE(combine(std::string{ kScoresFile1 } + ' ' + kScoresFile2, kCombinedFile));
+	ASSERT_FALSE(std::filesystem::exists(kCombinedFile));
+
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+}
+void endToEnd_combineFromOneEmptyFile() {
+	constexpr char const* kScoresFile1 = "scores_1.txt";
+	constexpr char const* kScoresFile2 = "scores_2.txt";
+	constexpr char const* kCombinedFile = "combined_scores.txt";
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kCombinedFile);
+
+	ASSERT_TRUE(saveScores({ { "item1", 3, 0 }, { "item2", 2, 1 }, { "item3", 1, 2 }, { "item4", 0, 3 } }, kScoresFile1));
+	std::ofstream file(kScoresFile2);
+	file.close();
+
+	ASSERT_TRUE(combine(std::string{ kScoresFile1 } + ' ' + kScoresFile2, kCombinedFile));
+	ASSERT_TRUE(std::filesystem::exists(kCombinedFile));
+
+	Scores const combined_scores = parseScores(loadFile(kCombinedFile));
+	ASSERT_EQ(combined_scores, Scores{ { "item1", 3, 0 }, { "item2", 2, 1 }, { "item3", 1, 2 }, { "item4", 0, 3 } });
+
+	std::filesystem::remove(kScoresFile1);
+	std::filesystem::remove(kScoresFile2);
+	std::filesystem::remove(kCombinedFile);
+}
 
 } // namespace
 
@@ -57,5 +182,11 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(combiningTwoScoreSetsWhenOneScoreSetIsEmpty);
 	RUN_TEST_IF_ARGUMENT_EQUALS(combiningTwoScoreSetsWithSameItem);
 	RUN_TEST_IF_ARGUMENT_EQUALS(combiningTwoScoreSetsWithDifferentItems);
+	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromTwoFiles);
+	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromThreeFiles);
+	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromTooFewFiles);
+	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromInvalidFileName);
+	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromAllEmptyFiles);
+	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromOneEmptyFile);
 	return 0;
 }


### PR DESCRIPTION
This moves the command-line input logic from combine() to pairwise_ranking, and thus makes the full combine logic testable.