### PR TITLE
Fix test dependency bug

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_testing()
 
-function(addTestSuite suite_name file_dependencies test_cases)
+function(addTestSuite suite_name test_dependencies test_cases)
 	add_executable(${suite_name}
 		${suite_name}.cpp
 		testing.cpp
-		${file_dependencies}
+		${test_dependencies}
 	)
 	target_include_directories(${suite_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
 	foreach (test_case ${test_cases})
@@ -36,7 +36,7 @@ list(APPEND test_cases
 	tooFewVotesToScoreAllItems
 )
 addTestSuite(test_calculate_scores "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -62,7 +62,7 @@ list(APPEND test_cases
 	endToEnd_combineFromOneEmptyFile
 )
 addTestSuite(test_combine_scores "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -84,7 +84,7 @@ list(APPEND test_cases
 	longItemNameAndWinsAndLosses
 )
 addTestSuite(test_create_score_table "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -103,7 +103,7 @@ list(APPEND test_cases
 	incompleteVotingIncreasesCounterAndChangesItem
 )
 addTestSuite(test_current_voting_line "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -122,7 +122,7 @@ list(APPEND test_cases
 	scoresAreTheSameDespiteDifferentItemOrderAndSeed
 )
 addTestSuite(test_e2e_voting_round "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -145,7 +145,7 @@ list(APPEND test_cases
 	generateWithFullVotingGivesCorrectScheduledVotes
 )
 addTestSuite(test_generate_new_voting_round "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -162,7 +162,7 @@ list(APPEND test_cases
 	multipleScores
 )
 addTestSuite(test_generate_score_file_data "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -179,7 +179,7 @@ list(APPEND test_cases
 	votingRoundWithOneVote
 )
 addTestSuite(test_generate_voting_round_file_data "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -197,7 +197,7 @@ list(APPEND test_cases
 	votingRoundCompleted
 )
 addTestSuite(test_get_active_menu_string "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -218,7 +218,7 @@ list(APPEND test_cases
 	scoresAreCalculatedWithCorrectItems
 )
 addTestSuite(test_item_order_randomized "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -236,7 +236,7 @@ list(APPEND test_cases
 	loadingNonExistingFile
 )
 addTestSuite(test_load_and_save_file "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -264,7 +264,7 @@ list(APPEND test_cases
 	nonNumbers
 )
 addTestSuite(test_parse_scores "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -302,7 +302,7 @@ list(APPEND test_cases
 	fourItemsAndFullVotingAndZeroVotes
 )
 addTestSuite(test_parse_voting_round "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -320,7 +320,7 @@ list(APPEND test_cases
 	pruningRemovesCorrectScheduledVotes
 )
 addTestSuite(test_prune_votes "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -335,7 +335,7 @@ list(APPEND test_cases
 	saveWhenSomeScores
 )
 addTestSuite(test_save_scores "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -350,7 +350,7 @@ list(APPEND test_cases
 	saveWhenNoVotesRemain
 )
 addTestSuite(test_save_votes "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -365,7 +365,7 @@ list(APPEND test_cases
 	shufflingWithSeedIsDeterministic
 )
 addTestSuite(test_shuffle_voting_order "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -380,7 +380,7 @@ list(APPEND test_cases
 	undoWhenNoVotesExist
 )
 addTestSuite(test_undo "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -399,7 +399,7 @@ list(APPEND test_cases
 	votingAfterRoundCompleted
 )
 addTestSuite(test_vote "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)
 
 
@@ -414,5 +414,5 @@ list(APPEND test_cases
 	formatToString
 )
 addTestSuite(test_voting_format "${test_dependencies}" "${test_cases}")
-unset(file_dependencies)
+unset(test_dependencies)
 unset(test_cases)

--- a/src/test/test_calculate_scores.cpp
+++ b/src/test/test_calculate_scores.cpp
@@ -286,5 +286,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingForOptionAButNotFullRound);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingForOptionBButNotFullRound);
 	RUN_TEST_IF_ARGUMENT_EQUALS(tooFewVotesToScoreAllItems);
-	return 0;
+	return 1;
 }

--- a/src/test/test_combine_scores.cpp
+++ b/src/test/test_combine_scores.cpp
@@ -188,5 +188,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromInvalidFileName);
 	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromAllEmptyFiles);
 	RUN_TEST_IF_ARGUMENT_EQUALS(endToEnd_combineFromOneEmptyFile);
-	return 0;
+	return 1;
 }

--- a/src/test/test_create_score_table.cpp
+++ b/src/test/test_create_score_table.cpp
@@ -129,5 +129,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(winLossDifferenceIsEqualAndNegative);
 	RUN_TEST_IF_ARGUMENT_EQUALS(shortItemNameAndWinsAndLosses);
 	RUN_TEST_IF_ARGUMENT_EQUALS(longItemNameAndWinsAndLosses);
-	return 0;
+	return 1;
 }

--- a/src/test/test_current_voting_line.cpp
+++ b/src/test/test_current_voting_line.cpp
@@ -69,5 +69,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(itemLengthIsEqualToHeaderLength);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingIsCompleted);
 	RUN_TEST_IF_ARGUMENT_EQUALS(incompleteVotingIncreasesCounterAndChangesItem);
-	return 0;
+	return 1;
 }

--- a/src/test/test_e2e_voting_round.cpp
+++ b/src/test/test_e2e_voting_round.cpp
@@ -132,5 +132,5 @@ int main(int argc, char* argv[]) {
 	ASSERT_EQ(argc, 2);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundIsTheSameAfterLoading);
 	RUN_TEST_IF_ARGUMENT_EQUALS(scoresAreTheSameDespiteDifferentItemOrderAndSeed);
-	return 0;
+	return 1;
 }

--- a/src/test/test_generate_new_voting_round.cpp
+++ b/src/test/test_generate_new_voting_round.cpp
@@ -387,5 +387,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithReducedVotingGivesCorrectAmountOfScheduledVotes);
 	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithFullVotingGivesCorrectScheduledVotes);
 
-	return 0;
+	return 1;
 }

--- a/src/test/test_generate_score_file_data.cpp
+++ b/src/test/test_generate_score_file_data.cpp
@@ -32,5 +32,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(oneScore);
 	RUN_TEST_IF_ARGUMENT_EQUALS(oneScoreWithSpacesInItemName);
 	RUN_TEST_IF_ARGUMENT_EQUALS(multipleScores);
-	return 0;
+	return 1;
 }

--- a/src/test/test_generate_voting_round_file_data.cpp
+++ b/src/test/test_generate_voting_round_file_data.cpp
@@ -60,5 +60,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundWithFullVoting);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundWithReducedVoting);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundWithOneVote);
-	return 0;
+	return 1;
 }

--- a/src/test/test_get_active_menu_string.cpp
+++ b/src/test/test_get_active_menu_string.cpp
@@ -32,5 +32,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(noVotingRoundCreated);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundStarted);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundCompleted);
-	return 0;
+	return 1;
 }

--- a/src/test/test_item_order_randomized.cpp
+++ b/src/test/test_item_order_randomized.cpp
@@ -114,5 +114,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(convertingVotingRoundToTextUsesOriginalItemOrder);
 	RUN_TEST_IF_ARGUMENT_EQUALS(scoresAreCalculatedWithCorrectItems);
 
-	return 0;
+	return 1;
 }

--- a/src/test/test_load_and_save_file.cpp
+++ b/src/test/test_load_and_save_file.cpp
@@ -91,5 +91,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(loadingNonExistingFile);
 
 	std::filesystem::remove(kTestFileName);
-	return 0;
+	return 1;
 }

--- a/src/test/test_parse_scores.cpp
+++ b/src/test/test_parse_scores.cpp
@@ -118,5 +118,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(validNumbers);
 	RUN_TEST_IF_ARGUMENT_EQUALS(nonNumbers);
 
-	return 0;
+	return 1;
 }

--- a/src/test/test_parse_voting_round.cpp
+++ b/src/test/test_parse_voting_round.cpp
@@ -432,5 +432,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(fourItemsAndFullVotingAndOneVote);
 	RUN_TEST_IF_ARGUMENT_EQUALS(fourItemsAndFullVotingAndZeroVotes);
 
-	return 0;
+	return 1;
 }

--- a/src/test/test_prune_votes.cpp
+++ b/src/test/test_prune_votes.cpp
@@ -216,5 +216,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(pruningAmountDuringVotingRoundCreationDependsOnNumberOfItems);
 	RUN_TEST_IF_ARGUMENT_EQUALS(parseVotingRoundWithPruning);
 	RUN_TEST_IF_ARGUMENT_EQUALS(pruningRemovesCorrectScheduledVotes);
-	return 0;
+	return 1;
 }

--- a/src/test/test_save_scores.cpp
+++ b/src/test/test_save_scores.cpp
@@ -35,5 +35,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenSomeScores);
 
 	std::filesystem::remove(kTestFileName);
-	return 0;
+	return 1;
 }

--- a/src/test/test_save_votes.cpp
+++ b/src/test/test_save_votes.cpp
@@ -44,5 +44,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenNoVotesRemain);
 
 	std::filesystem::remove(kTestFileName);
-	return 0;
+	return 1;
 }

--- a/src/test/test_shuffle_voting_order.cpp
+++ b/src/test/test_shuffle_voting_order.cpp
@@ -46,5 +46,5 @@ void shufflingWithSeedIsDeterministic() {
 int main(int argc, char* argv[]) {
 	ASSERT_EQ(argc, 2);
 	RUN_TEST_IF_ARGUMENT_EQUALS(shufflingWithSeedIsDeterministic);
-	return 0;
+	return 1;
 }

--- a/src/test/test_undo.cpp
+++ b/src/test/test_undo.cpp
@@ -23,5 +23,5 @@ int main(int argc, char* argv[]) {
 	ASSERT_EQ(argc, 2);
 	RUN_TEST_IF_ARGUMENT_EQUALS(undoWhenVotesExist);
 	RUN_TEST_IF_ARGUMENT_EQUALS(undoWhenNoVotesExist);
-	return 0;
+	return 1;
 }

--- a/src/test/test_vote.cpp
+++ b/src/test/test_vote.cpp
@@ -67,5 +67,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingForAForEachScheduledVote);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingForBForEachScheduledVote);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingAfterRoundCompleted);
-	return 0;
+	return 1;
 }

--- a/src/test/test_voting_format.cpp
+++ b/src/test/test_voting_format.cpp
@@ -43,5 +43,5 @@ int main(int argc, char* argv[]) {
 	RUN_TEST_IF_ARGUMENT_EQUALS(stringToFormatWithValidOptions);
 	RUN_TEST_IF_ARGUMENT_EQUALS(stringToFormatWithInalidOptions);
 	RUN_TEST_IF_ARGUMENT_EQUALS(formatToString);
-	return 0;
+	return 1;
 }


### PR DESCRIPTION
The wrong list was unset in CMakeLists, causing the real test_dependencies lists to never be unset and thus including each dependency file in each test.
The unset list is now corrected.

Also:
- tests now fail if an invalid test command is passed to them
- add newline to end of all test files