### PR TITLE
Combine all tests into one executable

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,25 +2,67 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_testing()
 
-function(addTestSuite suite_name dependencies cases)
-	add_executable(${suite_name}
-		${suite_name}.cpp
+function(addTestExe suites dependencies)
+	foreach (suite ${suites})
+		list(APPEND suites_cpp ${suite}.cpp)
+	endforeach()
+	add_executable(test
 		testing.cpp
+		test.cpp
+		${suites_cpp}
 		${dependencies}
 	)
-	target_include_directories(${suite_name} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+	target_include_directories(test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+endfunction()
+
+function(addTestSuite suite_name cases)
 	foreach (test_case ${cases})
-		add_test(NAME "${suite_name}/${test_case}" COMMAND ${suite_name} ${test_case})
+		add_test(NAME "${suite_name}/${test_case}" COMMAND test ${suite_name} ${test_case})
 	endforeach()
-	unset(test_dependencies PARENT_SCOPE)
 	unset(test_cases PARENT_SCOPE)
 endfunction()
 
-
 list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
+    ${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
+    ${PROJECT_SOURCE_DIR}/src/functions.cpp
+    ${PROJECT_SOURCE_DIR}/src/helpers.cpp
+    ${PROJECT_SOURCE_DIR}/src/menus.cpp
+    ${PROJECT_SOURCE_DIR}/src/print.cpp
+    ${PROJECT_SOURCE_DIR}/src/program_loop.cpp
+    ${PROJECT_SOURCE_DIR}/src/score.cpp
+    ${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
+    ${PROJECT_SOURCE_DIR}/src/test/mocks/mock_keyboard_input.cpp
+    ${PROJECT_SOURCE_DIR}/src/vote.cpp
+    ${PROJECT_SOURCE_DIR}/src/voting_format.cpp
+    ${PROJECT_SOURCE_DIR}/src/voting_round.cpp
 )
+list(APPEND test_suites
+	test_calculate_scores
+	test_combine_scores
+	test_create_score_table
+	test_current_voting_line
+	test_e2e_voting_round
+	test_end_to_end
+	test_generate_new_voting_round
+	test_generate_score_file_data
+	test_generate_voting_round_file_data
+	test_get_active_menu_string
+	test_item_order_randomized
+	test_load_and_save_file
+	test_parse_scores
+	test_parse_voting_round
+	test_prune_votes
+	test_rank_based_voting
+	test_save_scores
+	test_save_votes
+	test_shuffle_voting_order
+	test_undo
+	test_vote
+	test_voting_format
+)
+
+addTestExe("${test_suites}" "${test_dependencies}")
+
 list(APPEND test_cases
 	zeroItemsAndVotes
 	zeroVotes
@@ -40,15 +82,8 @@ list(APPEND test_cases
 	votingForOptionBButNotFullRound
 	tooFewVotesToScoreAllItems
 )
-addTestSuite(test_calculate_scores "${test_dependencies}" "${test_cases}")
+addTestSuite(test_calculate_scores "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
-)
 list(APPEND test_cases
 	combiningNoScoreSet
 	combiningOneScoreSetWithZeroScores
@@ -64,15 +99,8 @@ list(APPEND test_cases
 	endToEnd_combineFromAllEmptyFiles
 	endToEnd_combineFromOneEmptyFile
 )
-addTestSuite(test_combine_scores "${test_dependencies}" "${test_cases}")
+addTestSuite(test_combine_scores "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
-)
 list(APPEND test_cases
 	noScores
 	alreadySorted
@@ -84,15 +112,8 @@ list(APPEND test_cases
 	shortItemNameAndWinsAndLosses
 	longItemNameAndWinsAndLosses
 )
-addTestSuite(test_create_score_table "${test_dependencies}" "${test_cases}")
+addTestSuite(test_create_score_table "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	counterLengthEqualsTotalLength
 	counterLengthIsLessThanTotalLength
@@ -101,33 +122,14 @@ list(APPEND test_cases
 	votingIsCompleted
 	incompleteVotingIncreasesCounterAndChangesItem
 )
-addTestSuite(test_current_voting_line "${test_dependencies}" "${test_cases}")
+addTestSuite(test_current_voting_line "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	votingRoundIsTheSameAfterLoading
 	scoresAreTheSameDespiteDifferentItemOrderAndSeed
 )
-addTestSuite(test_e2e_voting_round "${test_dependencies}" "${test_cases}")
+addTestSuite(test_e2e_voting_round "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	generateWithTooFewItems
 	generateWithOnlyEmptyItems
@@ -139,63 +141,32 @@ list(APPEND test_cases
 	generateWithReducedVotingGivesCorrectAmountOfScheduledVotes
 	generateWithFullVotingGivesCorrectScheduledVotes
 )
-addTestSuite(test_generate_new_voting_round "${test_dependencies}" "${test_cases}")
+addTestSuite(test_generate_new_voting_round "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
-)
 list(APPEND test_cases
 	noScores
 	oneScore
 	oneScoreWithSpacesInItemName
 	multipleScores
 )
-addTestSuite(test_generate_score_file_data "${test_dependencies}" "${test_cases}")
+addTestSuite(test_generate_score_file_data "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	emptyVotingRound
 	votingRoundWithFullVoting
 	votingRoundWithReducedVoting
 	votingRoundWithOneVote
 )
-addTestSuite(test_generate_voting_round_file_data "${test_dependencies}" "${test_cases}")
+addTestSuite(test_generate_voting_round_file_data "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/menus.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	showIntro
 	noVotingRoundCreated
 	votingRoundStarted
 	votingRoundCompleted
 )
-addTestSuite(test_get_active_menu_string "${test_dependencies}" "${test_cases}")
+addTestSuite(test_get_active_menu_string "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	itemOrderIsShuffledWhenShufflingNewVotingRound
 	originalItemOrderIsRetainedWhenShufflingNewVotingRound
@@ -204,13 +175,8 @@ list(APPEND test_cases
 	convertingVotingRoundToTextUsesOriginalItemOrder
 	scoresAreCalculatedWithCorrectItems
 )
-addTestSuite(test_item_order_randomized "${test_dependencies}" "${test_cases}")
+addTestSuite(test_item_order_randomized "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-)
 list(APPEND test_cases
 	savingAndLoadingLines
 	savingAndLoadingLinesWithEmptyLines
@@ -220,15 +186,8 @@ list(APPEND test_cases
 	savingToExistingFile
 	loadingNonExistingFile
 )
-addTestSuite(test_load_and_save_file "${test_dependencies}" "${test_cases}")
+addTestSuite(test_load_and_save_file "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
-)
 list(APPEND test_cases
 	stringIsEmpty
 	stringIsValid
@@ -246,16 +205,8 @@ list(APPEND test_cases
 	validNumbers
 	nonNumbers
 )
-addTestSuite(test_parse_scores "${test_dependencies}" "${test_cases}")
+addTestSuite(test_parse_scores "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	noLinesToParse
 	noItemsBeforeEmptyLine
@@ -283,33 +234,16 @@ list(APPEND test_cases
 	fourItemsAndFullVotingAndOneVote
 	fourItemsAndFullVotingAndZeroVotes
 )
-addTestSuite(test_parse_voting_round "${test_dependencies}" "${test_cases}")
+addTestSuite(test_parse_voting_round "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	pruningDuringVotingRoundCreationWithTooFewItems
 	pruningAmountDuringVotingRoundCreationDependsOnNumberOfItems
 	parseVotingRoundWithPruning
 	pruningRemovesCorrectScheduledVotes
 )
-addTestSuite(test_prune_votes "${test_dependencies}" "${test_cases}")
+addTestSuite(test_prune_votes "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/menus.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	newRoundFormatStringPresentsAvailableVotingFormatsAndNumberOfVotes
 	createNewRankedVotingRound
@@ -330,68 +264,31 @@ list(APPEND test_cases
 	rankItemsBySortingWhenInitiallyUnranked
 	voteCounterAndApproximateTotalVotesIsPresented
 )
-addTestSuite(test_rank_based_voting "${test_dependencies}" "${test_cases}")
+addTestSuite(test_rank_based_voting "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
-)
 list(APPEND test_cases
 	saveWhenNoScores
 	saveWhenSomeScores
 )
-addTestSuite(test_save_scores "${test_dependencies}" "${test_cases}")
+addTestSuite(test_save_scores "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	saveWhenSomeVotesRemain
 	saveWhenNoVotesRemain
 )
-addTestSuite(test_save_votes "${test_dependencies}" "${test_cases}")
+addTestSuite(test_save_votes "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	shufflingWithSeedIsDeterministic
 )
-addTestSuite(test_shuffle_voting_order "${test_dependencies}" "${test_cases}")
+addTestSuite(test_shuffle_voting_order "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	undoWhenVotesExist
 	undoWhenNoVotesExist
 )
-addTestSuite(test_undo "${test_dependencies}" "${test_cases}")
+addTestSuite(test_undo "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/vote.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	firstVoteForA
 	firstVoteForB
@@ -399,12 +296,8 @@ list(APPEND test_cases
 	votingForBForEachScheduledVote
 	votingAfterRoundCompleted
 )
-addTestSuite(test_vote "${test_dependencies}" "${test_cases}")
+addTestSuite(test_vote "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-)
 list(APPEND test_cases
 	charToFormatWithValidOptions
 	charToFormatWithInvalidOptions
@@ -412,22 +305,8 @@ list(APPEND test_cases
 	stringToFormatWithInalidOptions
 	formatToString
 )
-addTestSuite(test_voting_format "${test_dependencies}" "${test_cases}")
+addTestSuite(test_voting_format "${test_cases}")
 
-
-list(APPEND test_dependencies
-	${PROJECT_SOURCE_DIR}/src/test/mocks/mock_keyboard_input.cpp
-	${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
-	${PROJECT_SOURCE_DIR}/src/functions.cpp
-	${PROJECT_SOURCE_DIR}/src/helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/menus.cpp
-	${PROJECT_SOURCE_DIR}/src/print.cpp
-	${PROJECT_SOURCE_DIR}/src/program_loop.cpp
-	${PROJECT_SOURCE_DIR}/src/score.cpp
-	${PROJECT_SOURCE_DIR}/src/score_helpers.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_format.cpp
-	${PROJECT_SOURCE_DIR}/src/voting_round.cpp
-)
 list(APPEND test_cases
 	mainMenuLegendPrinted
 	mainMenuLegendNotReprinted
@@ -505,4 +384,4 @@ list(APPEND test_cases
 	combineSaveScoresCancel
 	combineSaveScoresSuccessful
 )
-addTestSuite(test_end_to_end "${test_dependencies}" "${test_cases}")
+addTestSuite(test_end_to_end "${test_cases}")

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -1,0 +1,98 @@
+#include <string>
+#include <iostream>
+
+extern auto test_calculate_scores(std::string const&) -> int;
+extern auto test_combine_scores(std::string const&) -> int;
+extern auto test_create_score_table(std::string const&) -> int;
+extern auto test_current_voting_line(std::string const&) -> int;
+extern auto test_e2e_voting_round(std::string const&) -> int;
+extern auto test_end_to_end(std::string const&) -> int;
+extern auto test_generate_new_voting_round(std::string const&) -> int;
+extern auto test_generate_score_file_data(std::string const&) -> int;
+extern auto test_generate_voting_round_file_data(std::string const&) -> int;
+extern auto test_get_active_menu_string(std::string const&) -> int;
+extern auto test_item_order_randomized(std::string const&) -> int;
+extern auto test_load_and_save_file(std::string const&) -> int;
+extern auto test_parse_scores(std::string const&) -> int;
+extern auto test_parse_voting_round(std::string const&) -> int;
+extern auto test_prune_votes(std::string const&) -> int;
+extern auto test_rank_based_voting(std::string const&) -> int;
+extern auto test_save_scores(std::string const&) -> int;
+extern auto test_save_votes(std::string const&) -> int;
+extern auto test_shuffle_voting_order(std::string const&) -> int;
+extern auto test_undo(std::string const&) -> int;
+extern auto test_vote(std::string const&) -> int;
+extern auto test_voting_format(std::string const&) -> int;
+
+int main(int argc, char* argv[]) {
+	if (argc != 3) {
+		return 1;
+	}
+	if (std::string{ argv[1] } == "test_calculate_scores") {
+		return test_calculate_scores(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_combine_scores") {
+		return test_combine_scores(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_create_score_table") {
+		return test_create_score_table(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_current_voting_line") {
+		return test_current_voting_line(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_e2e_voting_round") {
+		return test_e2e_voting_round(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_end_to_end") {
+		return test_end_to_end(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_generate_new_voting_round") {
+		return test_generate_new_voting_round(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_generate_score_file_data") {
+		return test_generate_score_file_data(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_generate_voting_round_file_data") {
+		return test_generate_voting_round_file_data(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_get_active_menu_string") {
+		return test_get_active_menu_string(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_item_order_randomized") {
+		return test_item_order_randomized(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_load_and_save_file") {
+		return test_load_and_save_file(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_parse_scores") {
+		return test_parse_scores(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_parse_voting_round") {
+		return test_parse_voting_round(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_prune_votes") {
+		return test_prune_votes(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_rank_based_voting") {
+		return test_rank_based_voting(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_save_scores") {
+		return test_save_scores(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_save_votes") {
+		return test_save_votes(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_shuffle_voting_order") {
+		return test_shuffle_voting_order(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_undo") {
+		return test_undo(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_vote") {
+		return test_vote(argv[2]);
+	}
+	if (std::string{ argv[1] } == "test_voting_format") {
+		return test_voting_format(argv[2]);
+	}
+	return 1;
+}

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <optional>
+#include <source_location>
+#include <string>
+#include <vector>
+
+/* -------------- Test definitions -------------- */
+#define RUN_TEST_IF_ARGUMENT_EQUALS(test_name) if (test == #test_name) { test_name(); return false; }
+
+namespace detail
+{
+
+void assertion_failure(std::string const& error, std::source_location const& location);
+
+auto equalityStr(std::string const& a, std::string const& b, std::string const& eq_str) -> std::string;
+
+template<typename A, typename B>
+auto equalityString(A const& a, B const& b, std::string const& eq_str) -> std::string {
+	if constexpr (std::is_integral_v<A> && std::is_integral_v<B>) {
+		return equalityStr(std::to_string(a), std::to_string(b), eq_str);
+	}
+	else if constexpr (std::is_same_v<A, std::string> && std::is_same_v<B, std::string>) {
+		return equalityStr("'" + a + "'", "'" + b + "'", eq_str);
+	}
+	return "";
+}
+
+} // namespace detail
+
+/* -------------- Assertions to use in tests -------------- */
+template<typename A, typename B>
+void ASSERT_EQ(A const& a, B const& b, std::source_location const location = std::source_location::current()) {
+	if (a == b) {
+		return;
+	}
+	detail::assertion_failure(detail::equalityString(a, b, "equality"), location);
+}
+template<typename T>
+void ASSERT_NE(T const& a, T const& b, std::source_location const location = std::source_location::current()) {
+	if (a != b) {
+		return;
+	}
+	detail::assertion_failure(detail::equalityString(a, b, "inequality"), location);
+}
+void ASSERT_TRUE(bool a, std::source_location const location = std::source_location::current());
+void ASSERT_FALSE(bool a, std::source_location const location = std::source_location::current());
+
+/* -------------- Miscellaneous test helpers -------------- */
+template<typename T>
+auto operator+(std::vector<T> const& vec, T&& str) -> decltype(auto) {
+	auto new_vec = vec;
+	new_vec.emplace_back(str);
+	return new_vec;
+}
+template<typename T>
+auto operator+(std::vector<T> const& a, std::vector<T> const& b) -> decltype(auto) {
+	std::vector<T> vec;
+	vec.reserve(a.size() + b.size());
+	vec.insert(vec.end(), a.begin(), a.end());
+	vec.insert(vec.end(), b.begin(), b.end());
+	return vec;
+}
+auto getNItems(size_t n) -> std::vector<std::string>;

--- a/src/test/test_calculate_scores.cpp
+++ b/src/test/test_calculate_scores.cpp
@@ -268,8 +268,6 @@ void tooFewVotesToScoreAllItems() {
 	ASSERT_TRUE(scores.size() < kNumberOfItems);
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(zeroItemsAndVotes);
 	RUN_TEST_IF_ARGUMENT_EQUALS(zeroVotes);
@@ -291,9 +289,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_calculate_scores(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_combine_scores.cpp
+++ b/src/test/test_combine_scores.cpp
@@ -171,8 +171,6 @@ void endToEnd_combineFromOneEmptyFile() {
 	std::filesystem::remove(kCombinedFile);
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(combiningNoScoreSet);
 	RUN_TEST_IF_ARGUMENT_EQUALS(combiningOneScoreSetWithZeroScores);
@@ -190,9 +188,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_combine_scores(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_create_score_table.cpp
+++ b/src/test/test_create_score_table.cpp
@@ -116,8 +116,6 @@ void longItemNameAndWinsAndLosses() {
 // - Same item name
 // - TBD
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(noScores);
 	RUN_TEST_IF_ARGUMENT_EQUALS(alreadySorted);
@@ -131,9 +129,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_create_score_table(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_current_voting_line.cpp
+++ b/src/test/test_current_voting_line.cpp
@@ -59,8 +59,6 @@ void incompleteVotingIncreasesCounterAndChangesItem() {
 		std::string{ "(3/3) A: \'item2\'. B: \'item3\'." });
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(counterLengthEqualsTotalLength);
 	RUN_TEST_IF_ARGUMENT_EQUALS(counterLengthIsLessThanTotalLength);
@@ -71,9 +69,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_current_voting_line(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_e2e_voting_round.cpp
+++ b/src/test/test_e2e_voting_round.cpp
@@ -129,17 +129,16 @@ void scoresAreTheSameDespiteDifferentItemOrderAndSeed() {
 	ASSERT_EQ(findScore(scores_1, item_to_vote_for), findScore(scores_2, item_to_vote_for));
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundIsTheSameAfterLoading);
 	RUN_TEST_IF_ARGUMENT_EQUALS(scoresAreTheSameDespiteDifferentItemOrderAndSeed);
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_e2e_voting_round(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_end_to_end.cpp
+++ b/src/test/test_end_to_end.cpp
@@ -1254,8 +1254,6 @@ void combineSaveScoresSuccessful() {
 	cleanUpFiles(file_names);
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(mainMenuLegendPrinted);
 	RUN_TEST_IF_ARGUMENT_EQUALS(mainMenuLegendNotReprinted);
@@ -1335,10 +1333,11 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
+} // namespace
+
+auto test_end_to_end(std::string const& test_case) -> int {
 	cleanUpFiles();
-	if (run_tests(argv[1])) {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	ASSERT_TRUE(allActionsCompleted());

--- a/src/test/test_generate_new_voting_round.cpp
+++ b/src/test/test_generate_new_voting_round.cpp
@@ -373,8 +373,6 @@ void generateWithFullVotingGivesCorrectScheduledVotes() {
 		Vote{10, 11, Option::A} });
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithTooFewItems);
 	RUN_TEST_IF_ARGUMENT_EQUALS(generateWithOnlyEmptyItems);
@@ -388,9 +386,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_generate_new_voting_round(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_generate_score_file_data.cpp
+++ b/src/test/test_generate_score_file_data.cpp
@@ -24,8 +24,6 @@ void multipleScores() {
 	});
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(noScores);
 	RUN_TEST_IF_ARGUMENT_EQUALS(oneScore);
@@ -34,9 +32,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_generate_score_file_data(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_generate_voting_round_file_data.cpp
+++ b/src/test/test_generate_voting_round_file_data.cpp
@@ -52,8 +52,6 @@ void votingRoundWithOneVote() {
 	});
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(emptyVotingRound);
 	RUN_TEST_IF_ARGUMENT_EQUALS(votingRoundWithFullVoting);
@@ -62,9 +60,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_generate_voting_round_file_data(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_get_active_menu_string.cpp
+++ b/src/test/test_get_active_menu_string.cpp
@@ -24,8 +24,6 @@ void votingRoundCompleted() {
 			  std::string{ "Voting round finished. [H]elp. [Q]uit. Your choice: " });
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(showIntro);
 	RUN_TEST_IF_ARGUMENT_EQUALS(noVotingRoundCreated);
@@ -34,9 +32,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_get_active_menu_string(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_item_order_randomized.cpp
+++ b/src/test/test_item_order_randomized.cpp
@@ -102,8 +102,6 @@ void scoresAreCalculatedWithCorrectItems() {
 	}
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(itemOrderIsShuffledWhenShufflingNewVotingRound);
 	RUN_TEST_IF_ARGUMENT_EQUALS(originalItemOrderIsRetainedWhenShufflingNewVotingRound);
@@ -114,9 +112,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_item_order_randomized(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_load_and_save_file.cpp
+++ b/src/test/test_load_and_save_file.cpp
@@ -76,8 +76,6 @@ void loadingNonExistingFile() {
 	ASSERT_TRUE(loadFile(kTestFileName).empty());
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(savingAndLoadingLines);
 	RUN_TEST_IF_ARGUMENT_EQUALS(savingAndLoadingLinesWithEmptyLines);
@@ -89,10 +87,11 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
+} // namespace
+
+auto test_load_and_save_file(std::string const& test_case) -> int {
 	std::filesystem::remove(kTestFileName);
-	if (run_tests(argv[1])) {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	std::filesystem::remove(kTestFileName);

--- a/src/test/test_parse_scores.cpp
+++ b/src/test/test_parse_scores.cpp
@@ -96,7 +96,6 @@ void nonNumbers() {
 	ASSERT_EQ(Scores{}, parseScores({ "0 @ item1" }));
 	// Could exhaust more, but it's likely unnecessary
 }
-} // namespace
 
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(stringIsEmpty);
@@ -117,9 +116,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_parse_scores(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_parse_voting_round.cpp
+++ b/src/test/test_parse_voting_round.cpp
@@ -403,8 +403,6 @@ void fourItemsAndFullVotingAndZeroVotes() {
 	ASSERT_TRUE(voting_round.value().votes().empty());
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(noLinesToParse);
 	RUN_TEST_IF_ARGUMENT_EQUALS(noItemsBeforeEmptyLine);
@@ -434,9 +432,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_parse_voting_round(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_prune_votes.cpp
+++ b/src/test/test_prune_votes.cpp
@@ -208,8 +208,6 @@ void pruningRemovesCorrectScheduledVotes() {
 		Vote{7, 12, Option::A} });
 }
 
-} // namsepace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(pruningDuringVotingRoundCreationWithTooFewItems);
 	RUN_TEST_IF_ARGUMENT_EQUALS(pruningAmountDuringVotingRoundCreationDependsOnNumberOfItems);
@@ -218,9 +216,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namsepace
+
+auto test_prune_votes(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_rank_based_voting.cpp
+++ b/src/test/test_rank_based_voting.cpp
@@ -313,8 +313,6 @@ void voteCounterAndApproximateTotalVotesIsPresented() {
 	ASSERT_EQ(get_counter_string_then_vote_A(), std::string{ "( 19/~33)" });
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(newRoundFormatStringPresentsAvailableVotingFormatsAndNumberOfVotes);
 	RUN_TEST_IF_ARGUMENT_EQUALS(createNewRankedVotingRound);
@@ -337,9 +335,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_rank_based_voting(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_save_scores.cpp
+++ b/src/test/test_save_scores.cpp
@@ -25,18 +25,17 @@ void saveWhenSomeScores() {
 	std::filesystem::remove(kTestFileName);
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenNoScores);
 	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenSomeScores);
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
+} // namespace
+
+auto test_save_scores(std::string const& test_case) -> int {
 	std::filesystem::remove(kTestFileName);
-	if (run_tests(argv[1])) {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	std::filesystem::remove(kTestFileName);

--- a/src/test/test_save_votes.cpp
+++ b/src/test/test_save_votes.cpp
@@ -34,18 +34,17 @@ void saveWhenNoVotesRemain() {
 	std::filesystem::remove(kTestFileName);
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenSomeVotesRemain);
 	RUN_TEST_IF_ARGUMENT_EQUALS(saveWhenNoVotesRemain);
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
+} // namespace
+
+auto test_save_votes(std::string const& test_case) -> int {
 	std::filesystem::remove(kTestFileName);
-	if (run_tests(argv[1])) {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	std::filesystem::remove(kTestFileName);

--- a/src/test/test_shuffle_voting_order.cpp
+++ b/src/test/test_shuffle_voting_order.cpp
@@ -41,16 +41,15 @@ void shufflingWithSeedIsDeterministic() {
 		Vote{1, 7, Option::A} });
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(shufflingWithSeedIsDeterministic);
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_shuffle_voting_order(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_undo.cpp
+++ b/src/test/test_undo.cpp
@@ -17,17 +17,16 @@ void undoWhenNoVotesExist() {
 	ASSERT_FALSE(voting_round.value().undoVote());
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(undoWhenVotesExist);
 	RUN_TEST_IF_ARGUMENT_EQUALS(undoWhenNoVotesExist);
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_undo(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_vote.cpp
+++ b/src/test/test_vote.cpp
@@ -58,8 +58,6 @@ void votingAfterRoundCompleted() {
 	ASSERT_EQ(voting_round.value().votes().size(), 3ui64);
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(firstVoteForA);
 	RUN_TEST_IF_ARGUMENT_EQUALS(firstVoteForB);
@@ -69,9 +67,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_vote(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;

--- a/src/test/test_voting_format.cpp
+++ b/src/test/test_voting_format.cpp
@@ -34,8 +34,6 @@ void formatToString() {
 	ASSERT_EQ(votingFormatToString(VotingFormat::Invalid), std::string{ "" });
 }
 
-} // namespace
-
 auto run_tests(std::string const& test) -> bool {
 	RUN_TEST_IF_ARGUMENT_EQUALS(charToFormatWithValidOptions);
 	RUN_TEST_IF_ARGUMENT_EQUALS(charToFormatWithInvalidOptions);
@@ -45,9 +43,10 @@ auto run_tests(std::string const& test) -> bool {
 	return true;
 }
 
-int main(int argc, char* argv[]) {
-	ASSERT_EQ(argc, 2);
-	if (run_tests(argv[1])) {
+} // namespace
+
+auto test_voting_format(std::string const& test_case) -> int {
+	if (run_tests(test_case)) {
 		return 1;
 	}
 	return 0;


### PR DESCRIPTION
Previous solution separated each test suite into one executable each, to minimize rebuilds due to fewer dependencies for each test.

This change combines all tests into one executable, and runs the correct test suite and test case based on arguments. While this requires all tests to have all dependencies linked in the executable, there will only be one test executable which greatly reduces
build times.