### PR TITLE
Simplify test cases in CMakeLists

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,29 +2,14 @@ cmake_minimum_required(VERSION 3.15)
 
 enable_testing()
 
-function(addTestExe suites dependencies)
-	foreach (suite ${suites})
-		list(APPEND suites_cpp ${suite}.cpp)
-	endforeach()
-	add_executable(test
-		testing.cpp
-		test.cpp
-		${suites_cpp}
-		${dependencies}
-	)
-	target_include_directories(test PRIVATE ${PROJECT_SOURCE_DIR}/src)
-endfunction()
-
-function(addTestSuite suite_name cases)
-	foreach (test_case ${cases})
+function(addTestSuite suite_name #[[ARGN]])
+	foreach (test_case ${ARGN})
 		add_test(NAME "${suite_name}/${test_case}" COMMAND test ${suite_name} ${test_case})
 	endforeach()
-	unset(test_cases PARENT_SCOPE)
-	list(APPEND test_suites "${suite_name}")
-	set(test_suites ${test_suites} PARENT_SCOPE)
+	set(test_suites "${test_suites};${suite_name}" PARENT_SCOPE)
 endfunction()
 
-list(APPEND test_cases
+addTestSuite(test_calculate_scores
 	zeroItemsAndVotes
 	zeroVotes
 	oneVoteForA
@@ -43,9 +28,8 @@ list(APPEND test_cases
 	votingForOptionBButNotFullRound
 	tooFewVotesToScoreAllItems
 )
-addTestSuite(test_calculate_scores "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_combine_scores
 	combiningNoScoreSet
 	combiningOneScoreSetWithZeroScores
 	combiningOneScoreSetWithOneScore
@@ -60,9 +44,8 @@ list(APPEND test_cases
 	endToEnd_combineFromAllEmptyFiles
 	endToEnd_combineFromOneEmptyFile
 )
-addTestSuite(test_combine_scores "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_create_score_table
 	noScores
 	alreadySorted
 	reversedOrder
@@ -73,9 +56,8 @@ list(APPEND test_cases
 	shortItemNameAndWinsAndLosses
 	longItemNameAndWinsAndLosses
 )
-addTestSuite(test_create_score_table "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_current_voting_line
 	counterLengthEqualsTotalLength
 	counterLengthIsLessThanTotalLength
 	itemIsShorterThanLongestItem
@@ -83,15 +65,13 @@ list(APPEND test_cases
 	votingIsCompleted
 	incompleteVotingIncreasesCounterAndChangesItem
 )
-addTestSuite(test_current_voting_line "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_e2e_voting_round
 	votingRoundIsTheSameAfterLoading
 	scoresAreTheSameDespiteDifferentItemOrderAndSeed
 )
-addTestSuite(test_e2e_voting_round "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_generate_new_voting_round
 	generateWithTooFewItems
 	generateWithOnlyEmptyItems
 	generateWithSomeEmptyItems
@@ -102,33 +82,29 @@ list(APPEND test_cases
 	generateWithReducedVotingGivesCorrectAmountOfScheduledVotes
 	generateWithFullVotingGivesCorrectScheduledVotes
 )
-addTestSuite(test_generate_new_voting_round "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_generate_score_file_data
 	noScores
 	oneScore
 	oneScoreWithSpacesInItemName
 	multipleScores
 )
-addTestSuite(test_generate_score_file_data "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_generate_voting_round_file_data
 	emptyVotingRound
 	votingRoundWithFullVoting
 	votingRoundWithReducedVoting
 	votingRoundWithOneVote
 )
-addTestSuite(test_generate_voting_round_file_data "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_get_active_menu_string
 	showIntro
 	noVotingRoundCreated
 	votingRoundStarted
 	votingRoundCompleted
 )
-addTestSuite(test_get_active_menu_string "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_item_order_randomized
 	itemOrderIsShuffledWhenShufflingNewVotingRound
 	originalItemOrderIsRetainedWhenShufflingNewVotingRound
 	itemOrderIsShuffledWhenShufflingParsedVotingRound
@@ -136,9 +112,8 @@ list(APPEND test_cases
 	convertingVotingRoundToTextUsesOriginalItemOrder
 	scoresAreCalculatedWithCorrectItems
 )
-addTestSuite(test_item_order_randomized "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_load_and_save_file
 	savingAndLoadingLines
 	savingAndLoadingLinesWithEmptyLines
 	savingAndLoadingOnlyEmptyLines
@@ -147,9 +122,8 @@ list(APPEND test_cases
 	savingToExistingFile
 	loadingNonExistingFile
 )
-addTestSuite(test_load_and_save_file "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_parse_scores
 	stringIsEmpty
 	stringIsValid
 	itemIsAnInteger
@@ -166,9 +140,8 @@ list(APPEND test_cases
 	validNumbers
 	nonNumbers
 )
-addTestSuite(test_parse_scores "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_parse_voting_round
 	noLinesToParse
 	noItemsBeforeEmptyLine
 	fewerThanTwoItems
@@ -195,17 +168,15 @@ list(APPEND test_cases
 	fourItemsAndFullVotingAndOneVote
 	fourItemsAndFullVotingAndZeroVotes
 )
-addTestSuite(test_parse_voting_round "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_prune_votes
 	pruningDuringVotingRoundCreationWithTooFewItems
 	pruningAmountDuringVotingRoundCreationDependsOnNumberOfItems
 	parseVotingRoundWithPruning
 	pruningRemovesCorrectScheduledVotes
 )
-addTestSuite(test_prune_votes "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_rank_based_voting
 	newRoundFormatStringPresentsAvailableVotingFormatsAndNumberOfVotes
 	createNewRankedVotingRound
 	parseRankedVotingRoundWithNoVotes
@@ -225,50 +196,43 @@ list(APPEND test_cases
 	rankItemsBySortingWhenInitiallyUnranked
 	voteCounterAndApproximateTotalVotesIsPresented
 )
-addTestSuite(test_rank_based_voting "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_save_scores
 	saveWhenNoScores
 	saveWhenSomeScores
 )
-addTestSuite(test_save_scores "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_save_votes
 	saveWhenSomeVotesRemain
 	saveWhenNoVotesRemain
 )
-addTestSuite(test_save_votes "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_shuffle_voting_order
 	shufflingWithSeedIsDeterministic
 )
-addTestSuite(test_shuffle_voting_order "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_undo
 	undoWhenVotesExist
 	undoWhenNoVotesExist
 )
-addTestSuite(test_undo "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_vote
 	firstVoteForA
 	firstVoteForB
 	votingForAForEachScheduledVote
 	votingForBForEachScheduledVote
 	votingAfterRoundCompleted
 )
-addTestSuite(test_vote "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_voting_format
 	charToFormatWithValidOptions
 	charToFormatWithInvalidOptions
 	stringToFormatWithValidOptions
 	stringToFormatWithInalidOptions
 	formatToString
 )
-addTestSuite(test_voting_format "${test_cases}")
 
-list(APPEND test_cases
+addTestSuite(test_end_to_end
 	mainMenuLegendPrinted
 	mainMenuLegendNotReprinted
 	mainMenuNewVotingRound
@@ -345,9 +309,21 @@ list(APPEND test_cases
 	combineSaveScoresCancel
 	combineSaveScoresSuccessful
 )
-addTestSuite(test_end_to_end "${test_cases}")
 
-list(APPEND test_dependencies
+function(addTestExe test_suites #[[ARGN]])
+	foreach (test_suite ${test_suites})
+		list(APPEND test_suites_cpp ${test_suite}.cpp)
+	endforeach()
+	add_executable(test
+		testing.cpp
+		test.cpp
+		${test_suites_cpp}
+		${ARGN} # Dependencies
+	)
+	target_include_directories(test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+endfunction()
+
+addTestExe("${test_suites}"
     ${PROJECT_SOURCE_DIR}/src/calculate_scores.cpp
     ${PROJECT_SOURCE_DIR}/src/functions.cpp
     ${PROJECT_SOURCE_DIR}/src/helpers.cpp
@@ -361,5 +337,3 @@ list(APPEND test_dependencies
     ${PROJECT_SOURCE_DIR}/src/voting_format.cpp
     ${PROJECT_SOURCE_DIR}/src/voting_round.cpp
 )
-
-addTestExe("${test_suites}" "${test_dependencies}")

--- a/src/test/generate_ctests.py
+++ b/src/test/generate_ctests.py
@@ -1,80 +1,78 @@
 import glob, os, re
 
-os.chdir(os.path.dirname(__file__))
-
-test_suite_files = glob.glob("test_*.cpp")
-test_suites = [ name[:-4] for name in test_suite_files]
-
-with open("CMakeLists.txt", 'r') as cmake_file:
-	cmake_file_content = cmake_file.readlines()
-
 def findAllTestsInFile(file_name):
 	with open(file_name, 'r') as file:
 		file_content = file.read()
 		return [test[5:-2] for test in re.findall(r'void .*\(\)', file_content)]
 
-def findLineInList(list_to_search, line_to_find):
+def findLineIndexOfMatch(list_to_search, element) -> int:
 	for num, line in enumerate(list_to_search, 1):
-		if line_to_find in line:
-			return num
-	print("Failed to find " + line_to_find)
+		if element in line:
+			return num - 1
+	print("No match found for '" + element + "'")
 	return -1
 
-def findPreviousTestCaseList(list_to_search, line_number):
-	for num, line in reversed([x for x in enumerate(list_to_search, 1) ]):
-		if num >= line_number:
+def findLineIndexOfNextClosingParenthesis(list_to_search, starting_index):
+	for num, line in enumerate(list_to_search, 1):
+		if num < starting_index + 1:
 			continue
 		if "addTestSuite" in line:
 			break
-		if "list(APPEND test_cases" in line:
-			return num
-	print("No test_cases list found")
+		if ")" in line:
+			return num - 1
+	print("No match found for ')'")
 	return -1
 
-def findNextReturnInTestSuite(list_to_search, line_number):
+def findLineIndexOfNextReturn(list_to_search, starting_index):
 	for num, line in enumerate(list_to_search, 1):
-		if num < line_number:
+		if num < starting_index + 1:
 			continue
 		if "return true" in line:
-			return num
-	print("No return found")
+			return num - 1
+	print("No match found for 'return'")
 	return -1
 
-#### Update CMakeLists.txt #####
-for test_suite in test_suites:
-	add_test_suite_line = findLineInList(cmake_file_content, test_suite)
-	test_cases_list_line = findPreviousTestCaseList(cmake_file_content, add_test_suite_line)
+def updateCMakeLists(test_suite):
+	with open("CMakeLists.txt", 'r') as file:
+		cmake_file_data = file.readlines()
 
-	# Note: Conversion to index kept for clarity
-	test_cases_start_index = (test_cases_list_line - 1) + 1
-	test_cases_end_index   = (add_test_suite_line  - 1) - 2
+	# Find range of existing CTest cases
+	tests_start_index = findLineIndexOfMatch(cmake_file_data, test_suite) + 1
+	tests_end_index = findLineIndexOfNextClosingParenthesis(cmake_file_data, tests_start_index) - 1
 
-	del cmake_file_content[test_cases_start_index:test_cases_end_index+1]
-
-	cmake_file_content[test_cases_start_index:test_cases_start_index] = [
+	# Replace exiting CTest cases with tests found in source code
+	del cmake_file_data[tests_start_index:tests_end_index+1]
+	cmake_file_data[tests_start_index:tests_start_index] = [
 		'\t' + x + '\n'
 		for x in findAllTestsInFile(test_suite + ".cpp")
 	]
-	
+
 	with open("CMakeLists.txt", "w") as file:
-		file.write("".join(cmake_file_content))
-		
-##### Update test suite file #####
-for test_suite in test_suites:
-	with open(test_suite + ".cpp", 'r') as test_suite_file:
-		test_suite_file_content = test_suite_file.readlines()
-	run_tests_line = findLineInList(test_suite_file_content, "auto run_tests(std::string const& test)")
-	return_line = findNextReturnInTestSuite(test_suite_file_content, run_tests_line)
+		file.write("".join(cmake_file_data))
 
-	# Note: Conversion to index kept for clarity
-	run_test_start_index = (run_tests_line - 1) + 1
-	run_test_end_index   = (return_line - 1) - 1
+def updateTestSuiteFile(test_suite):
+	with open(test_suite + ".cpp", 'r') as file:
+		test_suite_data = file.readlines()
 
-	del test_suite_file_content[run_test_start_index:run_test_end_index+1]
-	test_suite_file_content[run_test_start_index:run_test_start_index] = [
+	# Find range of existing test macros
+	tests_start_index = findLineIndexOfMatch(test_suite_data, "auto run_tests(std::string const& test)") + 1
+	tests_end_index = findLineIndexOfNextReturn(test_suite_data, tests_start_index) - 1
+
+	# Replace existing test macros with tests found in source code
+	del test_suite_data[tests_start_index:tests_end_index+1]
+	test_suite_data[tests_start_index:tests_start_index] = [
 		"\tRUN_TEST_IF_ARGUMENT_EQUALS(" + x + ");\n"
 		for x in findAllTestsInFile(test_suite + ".cpp")
 	]
 
 	with open(test_suite + ".cpp", "w") as file:
-		file.write("".join(test_suite_file_content))
+		file.write("".join(test_suite_data))
+
+os.chdir(os.path.dirname(__file__))
+
+# Find all test suites
+test_suites = [ name[:-4] for name in glob.glob("test_*.cpp")]
+
+for test_suite in test_suites:
+	updateCMakeLists(test_suite)
+	updateTestSuiteFile(test_suite)


### PR DESCRIPTION
Test suites and test cases are now defined without needing to explicitly populate and reset a list of test cases. Instead, the test cases list is defined as multiple arguments to addTestSuite.

Test generation script is updated to conform to this.